### PR TITLE
wrap OsDirectory.getFiles to return OsPath[]

### DIFF
--- a/SimpleRssServer.Tests/DomainPrimitiveTypesTests.fs
+++ b/SimpleRssServer.Tests/DomainPrimitiveTypesTests.fs
@@ -3,6 +3,7 @@ module DomainPrimitiveTypesTests
 open Xunit
 open System
 open SimpleRssServer.DomainPrimitiveTypes
+open SimpleRssServer.Tests.TestHelpers
 
 [<Fact>]
 let ``Uri.create should return Ok for valid URI with dot in host`` () =
@@ -149,3 +150,17 @@ let ``Query.CreateWithKey empty list gives empty ToString`` () =
     let q = Query.CreateWithKey("rss", [])
     Assert.Empty(q.GetValues "rss")
     Assert.Equal("", q |> string)
+
+[<Fact>]
+let ``OsDirectory.getFiles returns OsPath array`` () =
+    use tmp = new TempDir()
+    let file1 = OsPath.join tmp.Path "file1.txt"
+    let file2 = OsPath.join tmp.Path "file2.txt"
+    OsFile.writeAllLines file1 [ "a" ]
+    OsFile.writeAllLines file2 [ "b" ]
+
+    let files = OsDirectory.getFiles tmp.Path
+
+    Assert.Equal(2, files.Length)
+    Assert.True(Array.contains file1 files)
+    Assert.True(Array.contains file2 files)

--- a/SimpleRssServer.Tests/ProgramTests.fs
+++ b/SimpleRssServer.Tests/ProgramTests.fs
@@ -270,7 +270,7 @@ let ``processRssRequest shows only error article on HTTP timeout with no cache``
 
     let cacheFiles =
         OsDirectory.getFiles cacheConfig.Dir
-        |> Array.filter (fun f -> not (f.EndsWith ".failures"))
+        |> Array.filter (fun (OsPath f) -> not (f.EndsWith ".failures"))
 
     Assert.Equal(0, cacheFiles.Length)
     Assert.Equal(None, memCache.TryGet(feedUrl, cacheConfig.Expiration))

--- a/SimpleRssServer.Tests/SimpleRssServer.Tests.fsproj
+++ b/SimpleRssServer.Tests/SimpleRssServer.Tests.fsproj
@@ -4,8 +4,8 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="DomainPrimitiveTypesTests.fs" />
     <Compile Include="TestHelpers.fs" />
+    <Compile Include="DomainPrimitiveTypesTests.fs" />
     <Compile Include="Roald87FeedReaderTests.fs" />
     <Compile Include="RssParserTests.fs" />
     <Compile Include="RequestTests.fs" />

--- a/SimpleRssServer/Cache.fs
+++ b/SimpleRssServer/Cache.fs
@@ -99,8 +99,8 @@ let clearExpiredCache (logger: ILogger) (cacheDir: OsPath) (retention: TimeSpan)
         let now = DateTime.Now
 
         OsDirectory.getFiles cacheDir
-        |> Array.filter (fun f -> (now - File.GetLastWriteTime f) > retention)
-        |> Array.iter File.Delete
+        |> Array.filter (fun f -> (now - OsFile.getLastWriteTime f) > retention)
+        |> Array.iter OsFile.delete
 
 let convertUrlToValidFilename (uri: Uri) =
     let replaceInvalidFilenameChars = RegularExpressions.Regex "[.?=:/]+"

--- a/SimpleRssServer/DomainPrimitiveTypes.fs
+++ b/SimpleRssServer/DomainPrimitiveTypes.fs
@@ -79,7 +79,9 @@ module OsDirectory =
         Directory.Delete(path, recursive = true)
 
     let exists (OsPath path) = Directory.Exists path
-    let getFiles (OsPath path) = Directory.GetFiles path
+
+    let getFiles (OsPath path) =
+        Directory.GetFiles path |> Array.map OsPath
 
 module OsFile =
     let exists (OsPath path) = File.Exists path


### PR DESCRIPTION
- `getFiles` was leaking `string[]` past the `OsPath` wrapper; fixed to return `OsPath[]`
- Updated `clearExpiredCache` and a `ProgramTests` call site to use `OsFile` helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)