### PR TITLE
add getOk helper and simplify Ok assertions

### DIFF
--- a/SimpleRssServer.Tests/DomainPrimitiveTypesTests.fs
+++ b/SimpleRssServer.Tests/DomainPrimitiveTypesTests.fs
@@ -10,9 +10,7 @@ let ``Uri.create should return Ok for valid URI with dot in host`` () =
     let input = "https://example.com"
     let result = FeedUri.create input
 
-    match result with
-    | Ok uri -> Assert.Equal("https://example.com/", uri.ToString())
-    | Error error -> failwithf $"Expected Ok but got Error: {error}"
+    Assert.Equal("https://example.com/", (getOk result).ToString())
 
 [<Fact>]
 let ``Uri.create should return Error for valid URI without dot in host`` () =
@@ -39,27 +37,21 @@ let ``Uri.createWithHttps should add https to URL without scheme`` () =
     let input = "example.com"
     let result = FeedUri.createWithHttps input
 
-    match result with
-    | Ok uri -> Assert.Equal("https://example.com/", uri.ToString())
-    | Error error -> failwithf $"Expected Ok but got Error: {error}"
+    Assert.Equal("https://example.com/", (getOk result).ToString())
 
 [<Fact>]
 let ``Uri.createWithHttps should keep http scheme`` () =
     let input = "http://example.com"
     let result = FeedUri.createWithHttps input
 
-    match result with
-    | Ok uri -> Assert.Equal("http://example.com/", uri.ToString())
-    | Error error -> failwithf $"Expected Ok but got Error: {error}"
+    Assert.Equal("http://example.com/", (getOk result).ToString())
 
 [<Fact>]
 let ``Uri.createWithHttps should keep https scheme`` () =
     let input = "https://example.com"
     let result = FeedUri.createWithHttps input
 
-    match result with
-    | Ok uri -> Assert.Equal("https://example.com/", uri.ToString())
-    | Error error -> failwithf $"Expected Ok but got Error: {error}"
+    Assert.Equal("https://example.com/", (getOk result).ToString())
 
 [<Fact>]
 let ``Uri.createWithHttps should return Error for invalid host`` () =

--- a/SimpleRssServer.Tests/HttpClientTests.fs
+++ b/SimpleRssServer.Tests/HttpClientTests.fs
@@ -35,9 +35,7 @@ let ``Test fetchUrlAsync with successful response`` () =
         fetchUrlAsync client logger (Uri "http://example.com") (Some DateTimeOffset.Now) (TimeSpan.FromSeconds 5.0)
         |> Async.RunSynchronously
 
-    match result with
-    | Ok result -> Assert.Equal(expectedContent, result)
-    | Error error -> failwithf $"Expected Success but got Failure: {error}"
+    Assert.Equal(expectedContent, getOk result)
 
 [<Fact>]
 let ``Test fetchUrlAsync with unsuccessful response`` () =
@@ -83,9 +81,7 @@ let ``GetAsync returns NotModified or OK based on IfModifiedSince header`` () =
         fetchUrlAsync client logger url (Some lastModifiedDate) (TimeSpan.FromSeconds 5.0)
         |> Async.RunSynchronously
 
-    match result1 with
-    | Ok content -> Assert.Equal("No changes", content)
-    | Error error -> failwithf $"Expected success, but got failure: {error}"
+    Assert.Equal("No changes", getOk result1)
 
     // Case 2: When If-Modified-Since is before lastModifiedDate
     let earlierDate = lastModifiedDate.AddDays -1.0
@@ -94,18 +90,14 @@ let ``GetAsync returns NotModified or OK based on IfModifiedSince header`` () =
         fetchUrlAsync client logger url (Some earlierDate) (TimeSpan.FromSeconds 5.0)
         |> Async.RunSynchronously
 
-    match result2 with
-    | Ok content -> Assert.Equal("Content has changed since the last modification date", content)
-    | Error error -> failwithf $"Expected success, but got failure: {error}"
+    Assert.Equal("Content has changed since the last modification date", getOk result2)
 
     // Case 3: When If-Modified-Since is not provided
     let result3 =
         fetchUrlAsync client logger url None (TimeSpan.FromSeconds 5.0)
         |> Async.RunSynchronously
 
-    match result3 with
-    | Ok content -> Assert.Equal("Content has changed since the last modification date", content)
-    | Error error -> failwithf $"Expected success, but got failure: {error}"
+    Assert.Equal("Content has changed since the last modification date", getOk result3)
 
 type DelayedResponseHandler(delay: TimeSpan) =
     inherit HttpMessageHandler()

--- a/SimpleRssServer.Tests/RequestTests.fs
+++ b/SimpleRssServer.Tests/RequestTests.fs
@@ -5,6 +5,7 @@ open Xunit
 
 open SimpleRssServer.DomainPrimitiveTypes
 open SimpleRssServer.Request
+open TestHelpers
 
 [<Fact>]
 let ``Test getRssUrls`` () =
@@ -50,9 +51,7 @@ let ``Test getRssUrls with valid and invalid URLs`` () =
     | Error(HostNameMustContainDot url) -> Assert.Contains("invalid-url", url.Value)
     | x -> failwithf $"Expected Error HostNameMustContainDot, but got {x}"
 
-    match result.[1] with
-    | Ok uri -> Assert.Equal(Uri "https://valid-url.com", uri)
-    | Error error -> failwithf $"Expected Ok, got Error: {error}"
+    Assert.Equal(Uri "https://valid-url.com", getOk result.[1])
 
 [<Fact>]
 let ``Test getRssUrls adds https if missing`` () =

--- a/SimpleRssServer.Tests/TestHelpers.fs
+++ b/SimpleRssServer.Tests/TestHelpers.fs
@@ -9,6 +9,11 @@ open System.Threading.Tasks
 
 open SimpleRssServer.DomainPrimitiveTypes
 
+let getOk =
+    function
+    | Ok x -> x
+    | Error e -> failwithf $"Expected Ok but got Error: {e}"
+
 let deleteFile (filePath: OsPath) =
     if OsFile.exists filePath then
         OsFile.delete filePath


### PR DESCRIPTION
Replaces 9 verbose 3-line `match result with | Ok x -> Assert... | Error e -> failwithf` blocks with `Assert.Equal(expected, getOk result)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)