### PR TITLE
Refactor domain model for clarity

### DIFF
--- a/SimpleRssServer/Cache.fs
+++ b/SimpleRssServer/Cache.fs
@@ -119,7 +119,7 @@ let readFromCache (cacheConfig: CacheConfig) (memCache: InMemoryCache) (ups: Uri
             | None -> PendingFetch(None, u)
             | Some modTime when (DateTimeOffset.Now - modTime) <= cacheConfig.Expiration ->
                 match readCache cachePath with
-                | Some s -> CachedFeed(s, u)
+                | Some s -> UnparsedCachedContent(s, u)
                 | None -> PendingFetch(None, u)
             | Some modTime -> PendingFetch(Some modTime, u)
     | ProcessingError e ->

--- a/SimpleRssServer/Cache.fs
+++ b/SimpleRssServer/Cache.fs
@@ -108,7 +108,7 @@ let convertUrlToValidFilename (uri: Uri) =
 
 let readFromCache (cacheConfig: CacheConfig) (memCache: InMemoryCache) (ups: UriProcessState) : UriProcessState =
     match ups with
-    | ValidUri(_, u) ->
+    | TryFetchFromCache u ->
         match memCache.TryGet(u.AbsoluteUri, cacheConfig.Expiration) with
         | Some articles -> FeedArticles articles
         | None ->
@@ -116,12 +116,12 @@ let readFromCache (cacheConfig: CacheConfig) (memCache: InMemoryCache) (ups: Uri
             let cacheModified = fileLastModified cachePath
 
             match cacheModified with
-            | None -> ValidUri(None, u)
+            | None -> PendingFetch(None, u)
             | Some modTime when (DateTimeOffset.Now - modTime) <= cacheConfig.Expiration ->
                 match readCache cachePath with
                 | Some s -> CachedFeed(s, u)
-                | None -> ValidUri(None, u)
-            | Some modTime -> ValidUri(Some modTime, u)
+                | None -> PendingFetch(None, u)
+            | Some modTime -> PendingFetch(Some modTime, u)
     | ProcessingError e ->
         let (MessageUri uriStr) = e
         let feedUri = Uri uriStr

--- a/SimpleRssServer/Cache.fs
+++ b/SimpleRssServer/Cache.fs
@@ -128,13 +128,13 @@ let readFromCache (cacheConfig: CacheConfig) (memCache: InMemoryCache) (ups: Uri
         let cachePath = OsPath.combine cacheConfig.Dir (convertUrlToValidFilename feedUri)
 
         match readCache cachePath with
-        | Some content -> StaleHitWithError(content, feedUri, e)
+        | Some content -> UnparsedStaleCachedContent(content, feedUri, e)
         | None -> ProcessingError e
     | _ -> ups
 
 let cacheSuccessfulFetch cacheConfig ups =
     match ups with
-    | ParsedFeed(xml, feed) ->
+    | ParsedLiveFeed(xml, feed) ->
         let cachePath =
             OsPath.combine cacheConfig.Dir (convertUrlToValidFilename (Uri feed.Link))
 

--- a/SimpleRssServer/DomainModel.fs
+++ b/SimpleRssServer/DomainModel.fs
@@ -39,7 +39,8 @@ type UnparsedXml =
         x
 
 type UriProcessState =
-    | ValidUri of (DateTimeOffset option) * Uri
+    | TryFetchFromCache of Uri
+    | PendingFetch of (DateTimeOffset option) * Uri
     | CachedFeed of string * Uri
     | Response of string * Uri
     | ResponseCanContainsFeeds of string * Uri

--- a/SimpleRssServer/DomainModel.fs
+++ b/SimpleRssServer/DomainModel.fs
@@ -44,13 +44,13 @@ type UriProcessState =
     | UnparsedCachedContent of string * Uri
     | UnparsedHttpResponse of string * Uri
     | NotRssContent of string * Uri
-    | ParsedFeed of UnparsedXml * Feed
+    | ParsedLiveFeed of UnparsedXml * Feed
     | ParsedCachedFeed of Feed
-    | StaleHitWithError of string * Uri * DomainError
-    | ParsedStaleHit of Feed * DomainError
+    | UnparsedStaleCachedContent of string * Uri * DomainError
+    | ParsedStaleFeed of Feed * DomainError
     | ProcessingError of DomainError
     | FeedArticles of Article list
-    | FeedWithErrorArticles of Article list
+    | DegradedArticles of Article list
 
 [<AutoOpen>]
 module ActivePatterns =

--- a/SimpleRssServer/DomainModel.fs
+++ b/SimpleRssServer/DomainModel.fs
@@ -41,9 +41,9 @@ type UnparsedXml =
 type UriProcessState =
     | TryFetchFromCache of Uri
     | PendingFetch of (DateTimeOffset option) * Uri
-    | CachedFeed of string * Uri
-    | Response of string * Uri
-    | ResponseCanContainsFeeds of string * Uri
+    | UnparsedCachedContent of string * Uri
+    | UnparsedHttpResponse of string * Uri
+    | NotRssContent of string * Uri
     | ParsedFeed of UnparsedXml * Feed
     | ParsedCachedFeed of Feed
     | StaleHitWithError of string * Uri * DomainMessage

--- a/SimpleRssServer/DomainModel.fs
+++ b/SimpleRssServer/DomainModel.fs
@@ -8,7 +8,7 @@ open Roald87.FeedReader
 
 type FeedUri = FeedUri of Uri
 
-and DomainMessage =
+and DomainError =
     // Uri errors
     | InvalidUriHostname of InvalidUri
     | InvalidUriFormat of InvalidUri * Exception
@@ -46,15 +46,15 @@ type UriProcessState =
     | NotRssContent of string * Uri
     | ParsedFeed of UnparsedXml * Feed
     | ParsedCachedFeed of Feed
-    | StaleHitWithError of string * Uri * DomainMessage
-    | ParsedStaleHit of Feed * DomainMessage
-    | ProcessingError of DomainMessage
+    | StaleHitWithError of string * Uri * DomainError
+    | ParsedStaleHit of Feed * DomainError
+    | ProcessingError of DomainError
     | FeedArticles of Article list
     | FeedWithErrorArticles of Article list
 
 [<AutoOpen>]
 module ActivePatterns =
-    let (|MessageUri|) (msg: DomainMessage) =
+    let (|MessageUri|) (msg: DomainError) =
         match msg with
         | InvalidUriHostname invalid -> invalid.Value
         | InvalidUriFormat(invalid, _) -> invalid.Value

--- a/SimpleRssServer/Helper.fs
+++ b/SimpleRssServer/Helper.fs
@@ -14,7 +14,7 @@ let isText (s: string) = not (String.IsNullOrWhiteSpace s)
 
 let toUriProcessState (uri: Result<Uri, UriError>) : UriProcessState =
     match uri with
-    | Ok u -> ValidUri(Some DateTimeOffset.Now, u)
+    | Ok u -> TryFetchFromCache u
     | Error u ->
         match u with
         | HostNameMustContainDot iu -> ProcessingError(InvalidUriHostname iu)

--- a/SimpleRssServer/Program.fs
+++ b/SimpleRssServer/Program.fs
@@ -107,8 +107,8 @@ let private getCacheAge (logger: ILogger) cacheConfig url =
             url
         )
 
-        Some(ValidUri(None, url))
-    | Some modTime when (DateTimeOffset.Now - modTime) > cacheConfig.Expiration -> Some(ValidUri(cacheAge, url))
+        Some(PendingFetch(None, url))
+    | Some modTime when (DateTimeOffset.Now - modTime) > cacheConfig.Expiration -> Some(PendingFetch(cacheAge, url))
     | _ -> None
 
 let updateCache client (logger: ILogger) cacheConfig (memCache: InMemoryCache) (urls: Uri list) =

--- a/SimpleRssServer/Request.fs
+++ b/SimpleRssServer/Request.fs
@@ -49,7 +49,7 @@ let private fetchUri client logger (cacheConfig: CacheConfig) (dt, uri) =
                     TryFetchFromCache uri
                 | Ok content ->
                     clearFailure cachePath
-                    Response(content, uri)
+                    UnparsedHttpResponse(content, uri)
                 | Error e ->
                     recordFailure logger cachePath
                     ProcessingError e

--- a/SimpleRssServer/Request.fs
+++ b/SimpleRssServer/Request.fs
@@ -1,7 +1,6 @@
 module SimpleRssServer.Request
 
 open System
-open System.IO
 
 open SimpleRssServer.Cache
 open SimpleRssServer.Config
@@ -10,9 +9,7 @@ open SimpleRssServer.DomainPrimitiveTypes
 open SimpleRssServer.HttpClient
 
 let getRssUrls (query: string) : Result<Uri, UriError> list =
-    Query.Create query
-    |> fun q -> q.GetValues "rss"
-    |> List.map FeedUri.createWithHttps
+    (Query.Create query).GetValues "rss" |> List.map FeedUri.createWithHttps
 
 type CacheState =
     | NoCacheNoFailures
@@ -49,7 +46,7 @@ let private fetchUri client logger (cacheConfig: CacheConfig) (dt, uri) =
                 | Ok "No changes" ->
                     OsFile.setLastWriteTime cachePath DateTime.Now
                     clearFailure cachePath
-                    ValidUri(Some DateTimeOffset.Now, uri)
+                    TryFetchFromCache uri
                 | Ok content ->
                     clearFailure cachePath
                     Response(content, uri)
@@ -59,16 +56,13 @@ let private fetchUri client logger (cacheConfig: CacheConfig) (dt, uri) =
     }
 
 let fetchAllRssFeeds client logger (cacheConfig: CacheConfig) (ups: UriProcessState list) =
-    let validUris, invalidUrls =
-        List.fold
-            (fun (valid, invalid) ups ->
-                match ups with
-                | ValidUri(dt, uri) -> (dt, uri) :: valid, invalid
-                | x -> valid, x :: invalid)
-            ([], [])
-            ups
-
     async {
-        let! processed = validUris |> List.map (fetchUri client logger cacheConfig) |> Async.Parallel
-        return List.ofArray processed @ invalidUrls
+        let! processed =
+            ups
+            |> List.map (function
+                | PendingFetch(dt, uri) -> fetchUri client logger cacheConfig (dt, uri)
+                | x -> async.Return x)
+            |> Async.Parallel
+
+        return List.ofArray processed
     }

--- a/SimpleRssServer/RequestLog.fs
+++ b/SimpleRssServer/RequestLog.fs
@@ -59,7 +59,7 @@ let uniqueValidRequestLogUrls (logPath: OsPath) =
 let logSuccessfulFeedRequestsAndParses (logPath: OsPath) (upss: UriProcessState list) =
     upss
     |> List.choose (function
-        | ParsedFeed(_, feed) -> Some(Uri feed.Link)
+        | ParsedLiveFeed(_, feed) -> Some(Uri feed.Link)
         | ParsedCachedFeed feed -> Some(Uri feed.Link)
         | _ -> None)
     |> updateRequestLog logPath RequestLogRetention

--- a/SimpleRssServer/RssParser.fs
+++ b/SimpleRssServer/RssParser.fs
@@ -20,7 +20,7 @@ let stripHtml (input: string) : string =
         htmlTagRegex.Replace(input, "")
         |> fun s -> whitespaceRegex.Replace(s, " ").Trim()
 
-let createErrorArticle (errorType: DomainMessage) : Article =
+let createErrorArticle (errorType: DomainError) : Article =
     let (MessageUri link) = errorType
 
     let text =
@@ -50,7 +50,7 @@ let createErrorArticle (errorType: DomainMessage) : Article =
       FeedUrl = link
       Text = text }
 
-let tryParseFeed (logger: ILogger) (content: string) (uri: Uri) : Result<Feed, DomainMessage> =
+let tryParseFeed (logger: ILogger) (content: string) (uri: Uri) : Result<Feed, DomainError> =
     try
         let feed = FeedReader.ReadFromString content
         // Link in feed points to the base url of the website, not the link to the feed.

--- a/SimpleRssServer/RssParser.fs
+++ b/SimpleRssServer/RssParser.fs
@@ -103,14 +103,14 @@ let feedToArticles (ups: UriProcessState) : UriProcessState =
 
 let parseFeedResult (logger: ILogger) (ups: UriProcessState) =
     match ups with
-    | Response(r, feedUri) ->
+    | UnparsedHttpResponse(r, feedUri) ->
         match tryParseFeed logger r feedUri with
         | Ok f -> ParsedFeed(UnparsedXml r, f)
         | Error e ->
             match e with
-            | InvalidRssFeedFormat _ -> ResponseCanContainsFeeds(r, feedUri)
+            | InvalidRssFeedFormat _ -> NotRssContent(r, feedUri)
             | _ -> ProcessingError e
-    | CachedFeed(r, feedUri) ->
+    | UnparsedCachedContent(r, feedUri) ->
         match tryParseFeed logger r feedUri with
         | Ok f -> ParsedCachedFeed f
         | Error e -> ProcessingError e
@@ -122,7 +122,7 @@ let parseFeedResult (logger: ILogger) (ups: UriProcessState) =
 
 let checkIfDiscoveryFeeds ups =
     match ups with
-    | ResponseCanContainsFeeds(s, originalUri) ->
+    | NotRssContent(s, originalUri) ->
         let feed = FeedReader.ParseFeedUrlsFromHtml s |> Seq.toList
 
         match feed with

--- a/SimpleRssServer/RssParser.fs
+++ b/SimpleRssServer/RssParser.fs
@@ -95,17 +95,17 @@ let toArticles (feed: Feed) =
 
 let feedToArticles (ups: UriProcessState) : UriProcessState =
     match ups with
-    | ParsedFeed(_, feed)
+    | ParsedLiveFeed(_, feed)
     | ParsedCachedFeed feed -> toArticles feed |> FeedArticles
-    | ParsedStaleHit(feed, err) -> toArticles feed @ [ createErrorArticle err ] |> FeedWithErrorArticles
-    | ProcessingError err -> [ createErrorArticle err ] |> FeedWithErrorArticles
+    | ParsedStaleFeed(feed, err) -> toArticles feed @ [ createErrorArticle err ] |> DegradedArticles
+    | ProcessingError err -> [ createErrorArticle err ] |> DegradedArticles
     | x -> x
 
 let parseFeedResult (logger: ILogger) (ups: UriProcessState) =
     match ups with
     | UnparsedHttpResponse(r, feedUri) ->
         match tryParseFeed logger r feedUri with
-        | Ok f -> ParsedFeed(UnparsedXml r, f)
+        | Ok f -> ParsedLiveFeed(UnparsedXml r, f)
         | Error e ->
             match e with
             | InvalidRssFeedFormat _ -> NotRssContent(r, feedUri)
@@ -114,9 +114,9 @@ let parseFeedResult (logger: ILogger) (ups: UriProcessState) =
         match tryParseFeed logger r feedUri with
         | Ok f -> ParsedCachedFeed f
         | Error e -> ProcessingError e
-    | StaleHitWithError(r, feedUri, err) ->
+    | UnparsedStaleCachedContent(r, feedUri, err) ->
         match tryParseFeed logger r feedUri with
-        | Ok f -> ParsedStaleHit(f, err)
+        | Ok f -> ParsedStaleFeed(f, err)
         | Error _ -> ProcessingError err
     | _ -> ups
 
@@ -133,5 +133,5 @@ let checkIfDiscoveryFeeds ups =
 let onlyFeedArticles ups =
     match ups with
     | FeedArticles articles
-    | FeedWithErrorArticles articles -> articles
+    | DegradedArticles articles -> articles
     | _ -> []

--- a/SimpleRssServer/RssParser.fs
+++ b/SimpleRssServer/RssParser.fs
@@ -127,7 +127,7 @@ let checkIfDiscoveryFeeds ups =
 
         match feed with
         | [] -> [ ProcessingError(NoRssFeedsFoundInPage originalUri) ]
-        | x -> x |> List.map (fun u -> ValidUri(None, Uri(originalUri, u.Url)))
+        | x -> x |> List.map (fun u -> TryFetchFromCache(Uri(originalUri, u.Url)))
     | x -> [ x ]
 
 let onlyFeedArticles ups =


### PR DESCRIPTION
Renames `UriProcessState` cases and simplifies `fetchAllRssFeeds`.

**State renames:**
- `ValidUri` split into `TryFetchFromCache` (try cache first) and `PendingFetch` (cache checked, go fetch)
- `CachedFeed` → `UnparsedCachedContent`
- `Response` → `UnparsedHttpResponse`
- `ResponseCanContainsFeeds` → `NotRssContent`
- `ParsedFeed` → `ParsedLiveFeed`
- `StaleHitWithError` → `UnparsedStaleCachedContent`
- `ParsedStaleHit` → `ParsedStaleFeed`
- `FeedWithErrorArticles` → `DegradedArticles`

**`fetchAllRssFeeds` simplified:** replaces `List.fold` split with `List.map` + `async.Return` for pass-through states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)