### PR TITLE
Add loading spinner and split request vs cache-refresh timeouts

### DIFF
--- a/SimpleRssServer.Tests/ProgramTests.fs
+++ b/SimpleRssServer.Tests/ProgramTests.fs
@@ -33,8 +33,7 @@ let makeCacheConfig () =
     OsDirectory.create cacheDir
 
     { Dir = cacheDir
-      Expiration = TimeSpan.FromHours 1.0
-      UpdateParallelism = 4 }
+      Expiration = TimeSpan.FromHours 1.0 }
 
 let createOutdatedCache (cachePath: OsPath) (content: string) =
     OsFile.writeAllText cachePath content

--- a/SimpleRssServer/Config.fs
+++ b/SimpleRssServer/Config.fs
@@ -4,17 +4,24 @@ open System
 open DomainPrimitiveTypes
 open System.Reflection
 
-type CacheConfig =
-    { Dir: OsPath
-      Expiration: TimeSpan
-      UpdateParallelism: int }
+type CacheConfig = { Dir: OsPath; Expiration: TimeSpan }
+
+type FetchConfig =
+    { MaxParallelism: int
+      Timeout: TimeSpan }
 
 let DefaultCacheConfig =
     { Dir = OsPath "rss-cache"
-      Expiration = TimeSpan.FromHours 1.0
-      UpdateParallelism = 8 }
+      Expiration = TimeSpan.FromHours 1.0 }
 
-let RequestTimeout = TimeSpan.FromSeconds 5.0
+let UserFetchConfig =
+    { MaxParallelism = Int32.MaxValue
+      Timeout = TimeSpan.FromSeconds 5.0 }
+
+let CacheRefreshFetchConfig =
+    { MaxParallelism = 8
+      Timeout = TimeSpan.FromSeconds 30.0 }
+
 let RequestLogPath = OsPath "rss-cache/request-log.txt"
 let RequestLogRetention = TimeSpan.FromDays 7.0
 let CacheRetention = TimeSpan.FromDays 7.0

--- a/SimpleRssServer/HtmlRenderer.fs
+++ b/SimpleRssServer/HtmlRenderer.fs
@@ -147,34 +147,57 @@ let private articlesToHtml (query: Query) (articles: Article list) : Html =
     |> List.map (fun a -> convertArticleToHtml deleteButtons[a.FeedUrl] a)
     |> Html.Concat
 
-let chronologicalFeedsPage (query: Query) (rssItems: Article list) : Html =
-    let body =
-        $"""
+let private loadingOverlay: Html =
+    Html """<div id="loading"><div class="spinner"></div><span>Loading feeds…</span></div>"""
+
+let private loadingHideStyle: Html =
+    Html """<style>#loading{display:none}</style>"""
+
+let chronologicalFeedsPageShell (query: Query) : Html =
+    $"""
     <body>
+        %s{string loadingOverlay}
         <div>
             <h1><a href="config.html/%s{query |> string}">rssrdr</a></h1>
             <a href="/config.html/%s{query |> string}">config/</a>
             <a href="/shuffle%s{query |> string}" style="margin-left: 20px;">shuffle/</a>
         </div>
     """
-        |> Html
+    |> Html
+    |> fun nav -> head + nav
 
-    let rssFeeds = rssItems |> List.sortByDescending _.PostDate |> articlesToHtml query
+let chronologicalFeedsPageContent (query: Query) (rssItems: Article list) : Html =
+    (rssItems |> List.sortByDescending _.PostDate |> articlesToHtml query)
+    + removeFeedScript
+    + loadingHideStyle
+    + footer
 
-    head + body + rssFeeds + removeFeedScript + footer
-
-let shuffledFeedsPage (query: Query) (rssItems: Article list) : Html =
-    let body =
-        $"""
+let shuffledFeedsPageShell (query: Query) : Html =
+    $"""
     <body>
+        %s{string loadingOverlay}
         <div>
             <h1><a href="config.html/%s{query |> string}">rssrdr</a></h1>
             <a href="/config.html/%s{query |> string}">config/</a>
             <a href="/%s{query |> string}" style="margin-left: 20px;">chronological/</a>
         </div>
     """
-        |> Html
+    |> Html
+    |> fun nav -> head + nav
 
-    let shuffledFeeds = rssItems |> List.randomShuffle |> articlesToHtml query
+let shuffledFeedsPageContent (query: Query) (rssItems: Article list) : Html =
+    (rssItems |> List.randomShuffle |> articlesToHtml query)
+    + removeFeedScript
+    + loadingHideStyle
+    + footer
 
-    head + body + shuffledFeeds + removeFeedScript + footer
+let metaRefreshContent (redirectUrl: string) : Html =
+    Html $"""<meta http-equiv="refresh" content="0; url={redirectUrl}">"""
+    + loadingHideStyle
+    + footer
+
+let chronologicalFeedsPage (query: Query) (rssItems: Article list) : Html =
+    chronologicalFeedsPageShell query + chronologicalFeedsPageContent query rssItems
+
+let shuffledFeedsPage (query: Query) (rssItems: Article list) : Html =
+    shuffledFeedsPageShell query + shuffledFeedsPageContent query rssItems

--- a/SimpleRssServer/Program.fs
+++ b/SimpleRssServer/Program.fs
@@ -22,12 +22,12 @@ let processRssRequest client (logger: ILogger) cacheConfig (memCache: InMemoryCa
 
     getRssUrls query
     |> List.map (toUriProcessState >> readCache) // try read cache before first fetch
-    |> fetchAllRssFeeds client logger cacheConfig Int32.MaxValue
+    |> fetchAllRssFeeds client logger cacheConfig UserFetchConfig
     |> Async.RunSynchronously
     |> List.map (readCache >> parseFeedResult logger) // read from cache in case of 304 Not modified
     |> List.collect checkIfDiscoveryFeeds
     |> List.map readCache // read discovered feeds from cache
-    |> fetchAllRssFeeds client logger cacheConfig Int32.MaxValue
+    |> fetchAllRssFeeds client logger cacheConfig UserFetchConfig
     |> Async.RunSynchronously
     |> List.map (
         readCache // previous fetch can contain 304s
@@ -65,35 +65,61 @@ let handleRequest
 
         let getSortedRssUris (q: Query) = q.GetValues "rss" |> List.sort
 
-        let buildFeedResponse render =
-            let rssArticles = getRssArticles ()
-            let procesedQuery = buildProcessedQuery rssArticles
-            let originalQuery = Query.Create context.Request.Url.Query
+        let writeResponse (content: string) =
+            async {
+                let buffer = content |> Encoding.UTF8.GetBytes
+                context.Response.ContentLength64 <- int64 buffer.Length
+                context.Response.ContentType <- "text/html"
 
-            if getSortedRssUris originalQuery <> getSortedRssUris procesedQuery then
-                context.Response.StatusCode <- HttpStatusCode.Found |> int
-                context.Response.RedirectLocation <- procesedQuery.ToString()
+                do!
+                    context.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length)
+                    |> Async.AwaitTask
 
-            render procesedQuery rssArticles |> string
+                context.Response.OutputStream.Close()
+            }
 
-        let! responseString =
-            match context.Request.RawUrl with
-            | Prefix "/config.html" _ -> async.Return(getRssUrls context.Request.Url.Query |> configPage |> string)
-            | Prefix "/shuffle?rss=" _ -> async.Return(buildFeedResponse shuffledFeedsPage)
-            | Prefix "/?rss=" _ -> async.Return(buildFeedResponse chronologicalFeedsPage)
-            | "/robots.txt" -> async.Return(File.ReadAllText(Path.Combine("site", "robots.txt")))
-            | "/sitemap.xml" -> async.Return(File.ReadAllText(Path.Combine("site", "sitemap.xml")))
-            | _ -> async.Return(landingPage |> string)
+        let writeChunk (html: Html) =
+            async {
+                let bytes = html |> string |> Encoding.UTF8.GetBytes
 
-        let buffer = responseString |> Encoding.UTF8.GetBytes
-        context.Response.ContentLength64 <- int64 buffer.Length
-        context.Response.ContentType <- "text/html"
+                do!
+                    context.Response.OutputStream.WriteAsync(bytes, 0, bytes.Length)
+                    |> Async.AwaitTask
 
-        do!
-            context.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length)
-            |> Async.AwaitTask
+                do! context.Response.OutputStream.FlushAsync() |> Async.AwaitTask
+            }
 
-        context.Response.OutputStream.Close()
+        let streamFeedResponse (shell: Html) (render: Query -> Article list -> Html) =
+            async {
+                context.Response.SendChunked <- true
+                context.Response.ContentType <- "text/html"
+                do! writeChunk shell
+
+                let articles = getRssArticles ()
+                let originalQuery = Query.Create context.Request.Url.Query
+                let processedQuery = buildProcessedQuery articles
+
+                let content =
+                    if getSortedRssUris originalQuery <> getSortedRssUris processedQuery then
+                        metaRefreshContent (string processedQuery)
+                    else
+                        render processedQuery articles
+
+                do! writeChunk content
+                context.Response.OutputStream.Close()
+            }
+
+        match context.Request.RawUrl with
+        | Prefix "/config.html" _ -> do! writeResponse (getRssUrls context.Request.Url.Query |> configPage |> string)
+        | Prefix "/shuffle?rss=" _ ->
+            let query = Query.Create context.Request.Url.Query
+            do! streamFeedResponse (shuffledFeedsPageShell query) shuffledFeedsPageContent
+        | Prefix "/?rss=" _ ->
+            let query = Query.Create context.Request.Url.Query
+            do! streamFeedResponse (chronologicalFeedsPageShell query) chronologicalFeedsPageContent
+        | "/robots.txt" -> do! writeResponse (File.ReadAllText(Path.Combine("site", "robots.txt")))
+        | "/sitemap.xml" -> do! writeResponse (File.ReadAllText(Path.Combine("site", "sitemap.xml")))
+        | _ -> do! writeResponse (landingPage |> string)
     }
 
 let private getCacheAge (logger: ILogger) cacheConfig url =
@@ -116,7 +142,7 @@ let updateCache client (logger: ILogger) cacheConfig (memCache: InMemoryCache) (
     if not (List.isEmpty urls) then
         urls
         |> List.choose (getCacheAge logger cacheConfig)
-        |> fetchAllRssFeeds client logger cacheConfig cacheConfig.UpdateParallelism
+        |> fetchAllRssFeeds client logger cacheConfig CacheRefreshFetchConfig
         |> Async.RunSynchronously
         |> List.iter (
             parseFeedResult logger

--- a/SimpleRssServer/Request.fs
+++ b/SimpleRssServer/Request.fs
@@ -28,7 +28,7 @@ let computeCacheAndBackoffState cacheModified nextAttempt expiration =
     | _, Some na -> InBackoffNoCache(TimeSpan.FromHours (na - DateTimeOffset.Now).TotalHours)
     | Some _, None -> CacheHit
 
-let private fetchUri client logger (cacheConfig: CacheConfig) (dt, uri) =
+let private fetchUri client logger (cacheConfig: CacheConfig) (fetchConfig: FetchConfig) (dt, uri) =
     async {
         let cachePath = OsPath.combine cacheConfig.Dir (convertUrlToValidFilename uri)
 
@@ -39,7 +39,7 @@ let private fetchUri client logger (cacheConfig: CacheConfig) (dt, uri) =
         | InBackoffWithCache waitTime -> return ProcessingError(PreviousHttpRequestFailedButPageCached(uri, waitTime))
         | InBackoffNoCache waitTime -> return ProcessingError(PreviousHttpRequestFailed(uri, waitTime))
         | _ ->
-            let! r = fetchUrlAsync client logger uri dt RequestTimeout
+            let! r = fetchUrlAsync client logger uri dt fetchConfig.Timeout
 
             return
                 match r with
@@ -58,14 +58,14 @@ let private fetchUri client logger (cacheConfig: CacheConfig) (dt, uri) =
                     ProcessingError e
     }
 
-let fetchAllRssFeeds client logger (cacheConfig: CacheConfig) maxParallelism (ups: UriProcessState list) =
+let fetchAllRssFeeds client logger (cacheConfig: CacheConfig) (fetchConfig: FetchConfig) (ups: UriProcessState list) =
     async {
         let! processed =
             ups
             |> List.map (function
-                | PendingFetch(dt, uri) -> fetchUri client logger cacheConfig (dt, uri)
+                | PendingFetch(dt, uri) -> fetchUri client logger cacheConfig fetchConfig (dt, uri)
                 | x -> async.Return x)
-            |> fun asyncs -> Async.Parallel(asyncs, maxParallelism)
+            |> fun asyncs -> Async.Parallel(asyncs, fetchConfig.MaxParallelism)
 
         return List.ofArray processed
     }

--- a/SimpleRssServer/site/head.html
+++ b/SimpleRssServer/site/head.html
@@ -107,5 +107,41 @@
         .remove-feed svg {
             pointer-events: none;
         }
+
+        #loading {
+            position: fixed;
+            inset: 0;
+            background: hsl(20, 100%, 95%);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 1em;
+            z-index: 999;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            #loading { background: hsl(20, 40%, 8%); }
+        }
+
+        .spinner {
+            width: 32px;
+            height: 32px;
+            border: 3px solid rgba(0, 0, 0, 0.15);
+            border-top-color: #555;
+            border-radius: 50%;
+            animation: spin 0.7s linear infinite;
+        }
+
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+
+        @media (prefers-color-scheme: dark) {
+            .spinner {
+                border-color: rgba(255, 255, 255, 0.15);
+                border-top-color: #aaa;
+            }
+        }
     </style>
 </head>


### PR DESCRIPTION
## Summary

- Stream feed pages in two HTTP chunks: the nav bar + CSS spinner is flushed immediately, then articles arrive after fetching — users see a spinner instead of a blank page
- Spinner hides itself via a `<style>#loading{display:none}</style>` appended with the article content (no JS)
- User request timeout: 5 s; background cache-refresh timeout: 30 s (previously one shared 5 s constant)
- New `FetchConfig { MaxParallelism; Timeout }` type replaces loose `maxParallelism` and `timeout` args on `fetchAllRssFeeds`, removing `UpdateParallelism` from `CacheConfig`

## Test plan

- [x] All 115 existing tests pass
- [x] Load a feed page cold — spinner should appear immediately, articles follow
- [ ] Confirm slow/timing-out feeds no longer time out during background refresh (30 s window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)