### PR TITLE
Bundle client/logger/cacheConfig/memCache into AppContext

### DIFF
--- a/SimpleRssServer.Tests/ProgramTests.fs
+++ b/SimpleRssServer.Tests/ProgramTests.fs
@@ -46,6 +46,12 @@ let makeTempLogPath () =
 
 let makeMemCache () = InMemoryCache NullLogger.Instance
 
+let makeCtx client cacheConfig memCache : AppContext =
+    { Client = client
+      Logger = NullLogger.Instance
+      CacheConfig = cacheConfig
+      MemCache = memCache }
+
 [<Fact>]
 let ``processRssRequest fetches feed, returns all articles, and writes cache`` () =
     // Arrange
@@ -59,7 +65,7 @@ let ``processRssRequest fetches feed, returns all articles, and writes cache`` (
 
     // Act
     let articles =
-        processRssRequest client NullLogger.Instance cacheConfig memCache logPath $"?rss={feedUrl}"
+        processRssRequest (makeCtx client cacheConfig memCache) logPath $"?rss={feedUrl}"
 
     // Assert
     Assert.Equal(articleCount, articles.Length)
@@ -96,7 +102,7 @@ let ``processRssRequest uses cached content when HTTP returns 304 Not Modified``
 
     // Act
     let articles =
-        processRssRequest client NullLogger.Instance cacheConfig memCache logPath $"?rss={feedUrl}"
+        processRssRequest (makeCtx client cacheConfig memCache) logPath $"?rss={feedUrl}"
 
     // Assert
     Assert.Equal(1, handler.CallCount)
@@ -133,7 +139,7 @@ let ``processRssRequest clears failure file when HTTP returns 304`` () =
 
     // Act
     let articles =
-        processRssRequest client NullLogger.Instance cacheConfig memCache (makeTempLogPath ()) $"?rss={feedUrl}"
+        processRssRequest (makeCtx client cacheConfig memCache) (makeTempLogPath ()) $"?rss={feedUrl}"
 
     // Assert
     Assert.False(OsFile.exists (failureFilePath cachePath), "Expected failure file to be removed after 304")
@@ -163,7 +169,7 @@ let ``processRssRequest serves articles from cache and makes no HTTP request`` (
 
     // Act
     let articles =
-        processRssRequest mockClientThrowsWhenCalled NullLogger.Instance cacheConfig memCache logPath $"?rss={feedUrl}"
+        processRssRequest (makeCtx mockClientThrowsWhenCalled cacheConfig memCache) logPath $"?rss={feedUrl}"
 
     // Assert
     Assert.Equal(articleCount, articles.Length)
@@ -203,7 +209,7 @@ let ``processRssRequest fetches via HTTP only on first call, subsequent calls re
 
     // Act & Assert — first call fetches both feeds
     let articles1 =
-        processRssRequest client NullLogger.Instance cacheConfig memCache logPath query
+        processRssRequest (makeCtx client cacheConfig memCache) logPath query
 
     Assert.Equal(2, handler.CallCount)
     Assert.Equal(articleCount * 2, articles1.Length)
@@ -212,13 +218,13 @@ let ``processRssRequest fetches via HTTP only on first call, subsequent calls re
 
     // Second and third calls must read from disk cache — HTTP call count stays at 2
     let articles2 =
-        processRssRequest client NullLogger.Instance cacheConfig memCache logPath query
+        processRssRequest (makeCtx client cacheConfig memCache) logPath query
 
     Assert.Equal(2, handler.CallCount)
     Assert.Equal(articleCount * 2, articles2.Length)
 
     let articles3 =
-        processRssRequest client NullLogger.Instance cacheConfig memCache logPath query
+        processRssRequest (makeCtx client cacheConfig memCache) logPath query
 
     Assert.Equal(2, handler.CallCount)
     Assert.Equal(articleCount * 2, articles3.Length)
@@ -245,7 +251,7 @@ let ``processRssRequest shows stale cache articles and error article on HTTP tim
 
     // Act
     let articles =
-        processRssRequest client NullLogger.Instance cacheConfig memCache (makeTempLogPath ()) $"?rss={feedUrl}"
+        processRssRequest (makeCtx client cacheConfig memCache) (makeTempLogPath ()) $"?rss={feedUrl}"
 
     // Assert: stale cached articles + one error article
     Assert.Equal(articleCount + 1, articles.Length)
@@ -263,7 +269,7 @@ let ``processRssRequest shows only error article on HTTP timeout with no cache``
 
     // Act
     let articles =
-        processRssRequest client NullLogger.Instance cacheConfig memCache (makeTempLogPath ()) $"?rss={feedUrl}"
+        processRssRequest (makeCtx client cacheConfig memCache) (makeTempLogPath ()) $"?rss={feedUrl}"
 
     // Assert: only one error article, no cache to fall back on
     Assert.Equal(1, articles.Length)
@@ -294,7 +300,7 @@ let ``processRssRequest shows PreviousHttpRequestFailed and skips HTTP on second
 
     // Act — first call: HTTP times out, failure file should be created
     let articles1 =
-        processRssRequest client NullLogger.Instance cacheConfig memCache (makeTempLogPath ()) $"?rss={feedUrl}"
+        processRssRequest (makeCtx client cacheConfig memCache) (makeTempLogPath ()) $"?rss={feedUrl}"
 
     Assert.Equal(1, handler.CallCount)
     Assert.Equal(1, articles1.Length)
@@ -303,7 +309,7 @@ let ``processRssRequest shows PreviousHttpRequestFailed and skips HTTP on second
 
     // Act — second call: should skip HTTP due to backoff
     let articles2 =
-        processRssRequest client NullLogger.Instance cacheConfig memCache (makeTempLogPath ()) $"?rss={feedUrl}"
+        processRssRequest (makeCtx client cacheConfig memCache) (makeTempLogPath ()) $"?rss={feedUrl}"
 
     // Assert: no new HTTP request made, error article reflects backoff
     Assert.Equal(1, handler.CallCount)
@@ -335,7 +341,7 @@ let ``processRssRequest shows PreviousHttpRequestFailedButPageCached and skips H
 
     // Act — first call: HTTP times out, stale cache shown, failure file should be created
     let articles1 =
-        processRssRequest client NullLogger.Instance cacheConfig memCache (makeTempLogPath ()) $"?rss={feedUrl}"
+        processRssRequest (makeCtx client cacheConfig memCache) (makeTempLogPath ()) $"?rss={feedUrl}"
 
     Assert.Equal(1, handler.CallCount)
     Assert.Equal(articleCount + 1, articles1.Length)
@@ -344,7 +350,7 @@ let ``processRssRequest shows PreviousHttpRequestFailedButPageCached and skips H
 
     // Act — second call: should skip HTTP due to backoff
     let articles2 =
-        processRssRequest client NullLogger.Instance cacheConfig memCache (makeTempLogPath ()) $"?rss={feedUrl}"
+        processRssRequest (makeCtx client cacheConfig memCache) (makeTempLogPath ()) $"?rss={feedUrl}"
 
     // Assert: no new HTTP request made, stale articles shown with backoff error
     Assert.Equal(1, handler.CallCount)
@@ -378,7 +384,7 @@ let ``processRssRequest retries and clears failure file when backoff period has 
 
     // Act
     let articles =
-        processRssRequest client NullLogger.Instance cacheConfig memCache (makeTempLogPath ()) $"?rss={feedUrl}"
+        processRssRequest (makeCtx client cacheConfig memCache) (makeTempLogPath ()) $"?rss={feedUrl}"
 
     // Assert — new content returned and failure file cleared
     Assert.Equal(articleCount, articles.Length)
@@ -413,7 +419,7 @@ let ``processRssRequest shows error article when HTML page has no feed links`` (
 
     // Act
     let articles =
-        processRssRequest client NullLogger.Instance cacheConfig memCache (makeTempLogPath ()) $"?rss={htmlUrl}"
+        processRssRequest (makeCtx client cacheConfig memCache) (makeTempLogPath ()) $"?rss={htmlUrl}"
 
     // Assert
     Assert.Equal(1, articles.Length)
@@ -450,7 +456,7 @@ let ``processRssRequest shows articles when HTML page has single feed link`` () 
 
     // Act
     let articles =
-        processRssRequest client NullLogger.Instance cacheConfig memCache logPath $"?rss={htmlUrl}"
+        processRssRequest (makeCtx client cacheConfig memCache) logPath $"?rss={htmlUrl}"
 
     // Assert: articles from discovered feed, no error
     Assert.Equal(articleCount, articles.Length)
@@ -486,7 +492,7 @@ let ``processRssRequest returns processed query with discovered feed URL instead
 
     // Act
     let articles =
-        processRssRequest client NullLogger.Instance cacheConfig memCache (makeTempLogPath ()) $"?rss={htmlUrl}"
+        processRssRequest (makeCtx client cacheConfig memCache) (makeTempLogPath ()) $"?rss={htmlUrl}"
 
     let queryUrls = getFeedUrlQuery articles |> fun x -> x.GetValues "rss"
 
@@ -525,7 +531,7 @@ let ``processRssRequest resolves relative feed URL in discovered feed against or
 
     // Act
     let articles =
-        processRssRequest client NullLogger.Instance cacheConfig memCache logPath $"?rss={htmlUrl}"
+        processRssRequest (makeCtx client cacheConfig memCache) logPath $"?rss={htmlUrl}"
 
     // Assert: relative feed URL was resolved, articles returned with no error
     Assert.Contains(articles, fun a -> a.FeedUrl = resolvedFeedUrl)
@@ -575,7 +581,7 @@ let ``updateCache fetches new feed content and overwrites stale cache files`` ()
     let memCache = makeMemCache ()
 
     // Act
-    updateCache client NullLogger.Instance cacheConfig memCache [ Uri feedUrl1; Uri feedUrl2 ]
+    updateCache (makeCtx client cacheConfig memCache) [ Uri feedUrl1; Uri feedUrl2 ]
 
     // Assert — new content is written to both cache files
     Assert.Equal(newXml1, OsFile.readAllText cachePath1)
@@ -609,7 +615,7 @@ let ``updateCache updates file write time but keeps cache content when server re
     let memCache = makeMemCache ()
 
     // Act
-    updateCache client NullLogger.Instance cacheConfig memCache [ Uri feedUrl ]
+    updateCache (makeCtx client cacheConfig memCache) [ Uri feedUrl ]
 
     // Assert — cache content is unchanged
     Assert.Equal(cachedXml, OsFile.readAllText cachePath)
@@ -635,7 +641,7 @@ let ``updateCache fetches and saves feed when no cache file exists`` () =
     let memCache = makeMemCache ()
 
     // Act
-    updateCache client NullLogger.Instance cacheConfig memCache [ Uri feedUrl ]
+    updateCache (makeCtx client cacheConfig memCache) [ Uri feedUrl ]
 
     // Assert — cache file is created with fetched content
     Assert.True(OsFile.exists cachePath)
@@ -664,7 +670,7 @@ let ``updateCache skips HTTP request and does not touch file when cache is still
     let memCache = makeMemCache ()
 
     // Act
-    updateCache client NullLogger.Instance cacheConfig memCache [ Uri feedUrl ]
+    updateCache (makeCtx client cacheConfig memCache) [ Uri feedUrl ]
 
     // Assert — no HTTP request was made
     Assert.Equal(0, handler.CallCount)
@@ -712,7 +718,7 @@ let ``processRssRequest shows articles from both feeds when HTML page has two fe
 
     // Act
     let articles =
-        processRssRequest client NullLogger.Instance cacheConfig memCache logPath $"?rss={htmlUrl}"
+        processRssRequest (makeCtx client cacheConfig memCache) logPath $"?rss={htmlUrl}"
 
     // Assert: articles from both discovered feeds, no error
     Assert.Equal(articleCount * 2, articles.Length)
@@ -744,10 +750,7 @@ let ``processRssRequest serves articles from memory cache and skips HTTP`` () =
     // Act — HTTP client throws if called
     let result =
         processRssRequest
-            mockClientThrowsWhenCalled
-            NullLogger.Instance
-            cacheConfig
-            memCache
+            (makeCtx mockClientThrowsWhenCalled cacheConfig memCache)
             (makeTempLogPath ())
             $"?rss={feedUrl}"
 
@@ -777,11 +780,11 @@ let ``processRssRequest falls through to disk cache when memory cache entry is s
     // Act — HTTP client throws if called (must serve from disk, not HTTP)
     let articles =
         processRssRequest
-            mockClientThrowsWhenCalled
-            NullLogger.Instance
-            { cacheConfig with
-                Expiration = TimeSpan.Zero }
-            memCache
+            (makeCtx
+                mockClientThrowsWhenCalled
+                { cacheConfig with
+                    Expiration = TimeSpan.Zero }
+                memCache)
             (makeTempLogPath ())
             $"?rss={feedUrl}"
 
@@ -808,14 +811,14 @@ let ``processRssRequest skips HTTP on second call when sharing InMemoryCache acr
 
     // Act — first call fetches from HTTP and populates memory cache
     let articles1 =
-        processRssRequest client NullLogger.Instance cacheConfig memCache (makeTempLogPath ()) $"?rss={feedUrl}"
+        processRssRequest (makeCtx client cacheConfig memCache) (makeTempLogPath ()) $"?rss={feedUrl}"
 
     Assert.Equal(1, handler.CallCount)
     Assert.Equal(articleCount, articles1.Length)
 
     // Act — second call with same InMemoryCache hits memory, no HTTP
     let articles2 =
-        processRssRequest client NullLogger.Instance cacheConfig memCache (makeTempLogPath ()) $"?rss={feedUrl}"
+        processRssRequest (makeCtx client cacheConfig memCache) (makeTempLogPath ()) $"?rss={feedUrl}"
 
     Assert.Equal(1, handler.CallCount)
     Assert.Equal(articleCount, articles2.Length)
@@ -884,7 +887,7 @@ let ``handleRequest strips https from discovered feed url in redirect`` () =
     let memCache = makeMemCache ()
 
     let articles =
-        processRssRequest client NullLogger.Instance cacheConfig memCache (makeTempLogPath ()) $"?rss={pagePath}"
+        processRssRequest (makeCtx client cacheConfig memCache) (makeTempLogPath ()) $"?rss={pagePath}"
 
     let result = buildProcessedQuery articles |> fun q -> q.GetValues "rss"
     Assert.Equal(1, result.Length)
@@ -918,7 +921,7 @@ let ``handleRequest keeps http scheme for discovered feed url in redirect`` () =
     let memCache = makeMemCache ()
 
     let articles =
-        processRssRequest client NullLogger.Instance cacheConfig memCache (makeTempLogPath ()) $"?rss={pagePath}"
+        processRssRequest (makeCtx client cacheConfig memCache) (makeTempLogPath ()) $"?rss={pagePath}"
 
     let result = buildProcessedQuery articles |> fun q -> q.GetValues "rss"
     Assert.Equal(1, result.Length)

--- a/SimpleRssServer/Program.fs
+++ b/SimpleRssServer/Program.fs
@@ -17,6 +17,12 @@ open SimpleRssServer.RssParser
 open SimpleRssServer.DomainModel
 open SimpleRssServer.DomainPrimitiveTypes
 
+type AppContext =
+    { Client: Http.HttpClient
+      Logger: ILogger
+      CacheConfig: CacheConfig
+      MemCache: InMemoryCache }
+
 let private readFormBody (context: HttpListenerContext) =
     async {
         use reader = new StreamReader(context.Request.InputStream, Encoding.UTF8)
@@ -24,25 +30,25 @@ let private readFormBody (context: HttpListenerContext) =
         return Query.Create("?" + body)
     }
 
-let processRssRequest client (logger: ILogger) cacheConfig (memCache: InMemoryCache) (logPath: OsPath) (query: string) =
-    let readCache = readFromCache cacheConfig memCache
+let processRssRequest (ctx: AppContext) (logPath: OsPath) (query: string) =
+    let readCache = readFromCache ctx.CacheConfig ctx.MemCache
 
     getRssUrls query
     |> List.map (toUriProcessState >> readCache) // try read cache before first fetch
-    |> fetchAllRssFeeds client logger cacheConfig UserFetchConfig
+    |> fetchAllRssFeeds ctx.Client ctx.Logger ctx.CacheConfig UserFetchConfig
     |> Async.RunSynchronously
-    |> List.map (readCache >> parseFeedResult logger) // read from cache in case of 304 Not modified
+    |> List.map (readCache >> parseFeedResult ctx.Logger) // read from cache in case of 304 Not modified
     |> List.collect checkIfDiscoveryFeeds
     |> List.map readCache // read discovered feeds from cache
-    |> fetchAllRssFeeds client logger cacheConfig UserFetchConfig
+    |> fetchAllRssFeeds ctx.Client ctx.Logger ctx.CacheConfig UserFetchConfig
     |> Async.RunSynchronously
     |> List.map (
         readCache // previous fetch can contain 304s
-        >> parseFeedResult logger
-        >> cacheSuccessfulFetch cacheConfig
+        >> parseFeedResult ctx.Logger
+        >> cacheSuccessfulFetch ctx.CacheConfig
     )
     |> logSuccessfulFeedRequestsAndParses logPath
-    |> List.map (feedToArticles >> updateMemoryCache memCache)
+    |> List.map (feedToArticles >> updateMemoryCache ctx.MemCache)
     |> List.collect onlyFeedArticles
 
 let getFeedUrlQuery articles =
@@ -92,10 +98,7 @@ let private redirectTo (context: HttpListenerContext) (url: string) =
 /// Streams a feeds page for the current request's own `?rss=` query, redirecting first
 /// if fetching/discovery normalized the feed list (e.g. stripped a scheme, followed a discovery link).
 let private streamFeedResponse
-    client
-    (logger: ILogger)
-    cacheConfig
-    (memCache: InMemoryCache)
+    (ctx: AppContext)
     (context: HttpListenerContext)
     (shell: Html)
     (render: Query -> Article list -> Html)
@@ -105,8 +108,7 @@ let private streamFeedResponse
         context.Response.ContentType <- "text/html"
         do! writeChunk context shell
 
-        let articles =
-            processRssRequest client logger cacheConfig memCache RequestLogPath context.Request.Url.Query
+        let articles = processRssRequest ctx RequestLogPath context.Request.Url.Query
 
         let originalQuery = Query.Create context.Request.Url.Query
         let processedQuery = buildProcessedQuery articles
@@ -173,10 +175,7 @@ let private handleUpdateCollection (context: HttpListenerContext) (collectionId:
     }
 
 let private handleViewCollection
-    client
-    (logger: ILogger)
-    cacheConfig
-    (memCache: InMemoryCache)
+    (ctx: AppContext)
     (context: HttpListenerContext)
     (collectionId: CollectionId)
     (shell: Html)
@@ -191,59 +190,33 @@ let private handleViewCollection
 
             do! writeChunk context shell
 
-            let articles =
-                processRssRequest client logger cacheConfig memCache RequestLogPath (string collQuery)
+            let articles = processRssRequest ctx RequestLogPath (string collQuery)
 
             do! writeChunk context (content collQuery articles)
             context.Response.OutputStream.Close()
         })
 
-let handleRequest
-    client
-    (logger: ILogger)
-    (cacheConfig: CacheConfig)
-    (memCache: InMemoryCache)
-    (context: HttpListenerContext)
-    =
+let handleRequest (ctx: AppContext) (context: HttpListenerContext) =
     async {
-        logger.LogDebug $"Received request {context.Request.Url}"
+        ctx.Logger.LogDebug $"Received request {context.Request.Url}"
 
         match context.Request.RawUrl with
         | Prefix "/config.html" _ -> do! handleConfigPage context
         | Prefix "/shuffle?rss=" _ ->
             let query = Query.Create context.Request.Url.Query
 
-            do!
-                streamFeedResponse
-                    client
-                    logger
-                    cacheConfig
-                    memCache
-                    context
-                    (shuffledFeedsPageShell query)
-                    shuffledFeedsPageContent
+            do! streamFeedResponse ctx context (shuffledFeedsPageShell query) shuffledFeedsPageContent
         | Prefix "/?rss=" _ ->
             let query = Query.Create context.Request.Url.Query
 
-            do!
-                streamFeedResponse
-                    client
-                    logger
-                    cacheConfig
-                    memCache
-                    context
-                    (chronologicalFeedsPageShell query)
-                    chronologicalFeedsPageContent
+            do! streamFeedResponse ctx context (chronologicalFeedsPageShell query) chronologicalFeedsPageContent
         | "/robots.txt" -> do! writeResponse context (File.ReadAllText(Path.Combine("site", "robots.txt")))
         | "/sitemap.xml" -> do! writeResponse context (File.ReadAllText(Path.Combine("site", "sitemap.xml")))
         | "/s" when context.Request.HttpMethod = "POST" -> do! handleCreateCollection context
         | CollectionShuffleId collectionId when context.Request.HttpMethod = "GET" ->
             do!
                 handleViewCollection
-                    client
-                    logger
-                    cacheConfig
-                    memCache
+                    ctx
                     context
                     collectionId
                     (collectionShuffledPageShell collectionId)
@@ -251,10 +224,7 @@ let handleRequest
         | CollectionIdPath collectionId when context.Request.HttpMethod = "GET" ->
             do!
                 handleViewCollection
-                    client
-                    logger
-                    cacheConfig
-                    memCache
+                    ctx
                     context
                     collectionId
                     (collectionFeedsPageShell collectionId)
@@ -280,30 +250,29 @@ let private getCacheAge (logger: ILogger) cacheConfig url =
     | Some modTime when (DateTimeOffset.Now - modTime) > cacheConfig.Expiration -> Some(PendingFetch(cacheAge, url))
     | _ -> None
 
-let updateCache client (logger: ILogger) cacheConfig (memCache: InMemoryCache) (urls: Uri list) =
+let updateCache (ctx: AppContext) (urls: Uri list) =
     if not (List.isEmpty urls) then
         urls
-        |> List.choose (getCacheAge logger cacheConfig)
-        |> fetchAllRssFeeds client logger cacheConfig CacheRefreshFetchConfig
+        |> List.choose (getCacheAge ctx.Logger ctx.CacheConfig)
+        |> fetchAllRssFeeds ctx.Client ctx.Logger ctx.CacheConfig CacheRefreshFetchConfig
         |> Async.RunSynchronously
         |> List.iter (
-            parseFeedResult logger
-            >> cacheSuccessfulFetch cacheConfig
+            parseFeedResult ctx.Logger
+            >> cacheSuccessfulFetch ctx.CacheConfig
             >> feedToArticles
-            >> updateMemoryCache memCache
+            >> updateMemoryCache ctx.MemCache
             >> ignore
         )
 
 [<TailCall>]
-let rec updateRssFeedsPeriodically client (logger: ILogger) (cacheConfig: CacheConfig) (memCache: InMemoryCache) =
+let rec updateRssFeedsPeriodically (ctx: AppContext) =
     async {
-        logger.LogDebug "Periodically updating RSS feeds."
+        ctx.Logger.LogDebug "Periodically updating RSS feeds."
 
-        uniqueValidRequestLogUrls RequestLogPath
-        |> updateCache client logger cacheConfig memCache
+        uniqueValidRequestLogUrls RequestLogPath |> updateCache ctx
 
-        do! Async.Sleep cacheConfig.Expiration
-        return! updateRssFeedsPeriodically client logger cacheConfig memCache
+        do! Async.Sleep ctx.CacheConfig.Expiration
+        return! updateRssFeedsPeriodically ctx
     }
 
 [<TailCall>]
@@ -317,32 +286,20 @@ let rec clearCachePeriodically (logger: ILogger) (cacheDir: OsPath) (retention: 
         return! clearCachePeriodically logger cacheDir retention period
     }
 
-let private handleRequestSafely
-    (httpClient: Http.HttpClient)
-    (logger: ILogger)
-    (cacheConfig: SimpleRssServer.Config.CacheConfig)
-    (feedCache: InMemoryCache)
-    context
-    =
+let private handleRequestSafely (ctx: AppContext) context =
     async {
         try
-            do! handleRequest httpClient logger cacheConfig feedCache context
+            do! handleRequest ctx context
         with ex ->
-            logger.LogInformation("Request handling error: {Message}", ex.Message)
+            ctx.Logger.LogInformation("Request handling error: {Message}", ex.Message)
     }
 
 [<TailCall>]
-let rec private serverLoop
-    (listener: HttpListener)
-    (httpClient: Http.HttpClient)
-    (logger: ILogger)
-    (cacheConfig: SimpleRssServer.Config.CacheConfig)
-    (feedCache: InMemoryCache)
-    =
+let rec private serverLoop (listener: HttpListener) (ctx: AppContext) =
     async {
         let! context = listener.GetContextAsync() |> Async.AwaitTask
-        do! handleRequestSafely httpClient logger cacheConfig feedCache context
-        return! serverLoop listener httpClient logger cacheConfig feedCache
+        do! handleRequestSafely ctx context
+        return! serverLoop listener ctx
     }
 
 let startServer (logger: ILogger) (cacheConfig: SimpleRssServer.Config.CacheConfig) (hosts: string list) =
@@ -354,15 +311,18 @@ let startServer (logger: ILogger) (cacheConfig: SimpleRssServer.Config.CacheConf
     let addresses = hosts |> String.concat ", "
     logger.LogInformation("Listening at {Addresses}", addresses)
 
-    let httpClient = new Http.HttpClient()
-    let feedCache = InMemoryCache logger
+    let ctx =
+        { Client = new Http.HttpClient()
+          Logger = logger
+          CacheConfig = cacheConfig
+          MemCache = InMemoryCache logger }
 
-    Async.Start(updateRssFeedsPeriodically httpClient logger cacheConfig feedCache)
+    Async.Start(updateRssFeedsPeriodically ctx)
 
     let cacheCleanupPeriod = TimeSpan.FromDays 1.0
     Async.Start(clearCachePeriodically logger cacheConfig.Dir CacheRetention cacheCleanupPeriod)
 
-    serverLoop listener httpClient logger cacheConfig feedCache
+    serverLoop listener ctx
 
 let helpMessage =
     """

--- a/SimpleRssServer/Program.fs
+++ b/SimpleRssServer/Program.fs
@@ -30,25 +30,25 @@ let private readFormBody (context: HttpListenerContext) =
         return Query.Create("?" + body)
     }
 
-let processRssRequest (ctx: AppContext) (logPath: OsPath) (query: string) =
-    let readCache = readFromCache ctx.CacheConfig ctx.MemCache
+let processRssRequest (appCtx: AppContext) (logPath: OsPath) (query: string) =
+    let readCache = readFromCache appCtx.CacheConfig appCtx.MemCache
 
     getRssUrls query
     |> List.map (toUriProcessState >> readCache) // try read cache before first fetch
-    |> fetchAllRssFeeds ctx.Client ctx.Logger ctx.CacheConfig UserFetchConfig
+    |> fetchAllRssFeeds appCtx.Client appCtx.Logger appCtx.CacheConfig UserFetchConfig
     |> Async.RunSynchronously
-    |> List.map (readCache >> parseFeedResult ctx.Logger) // read from cache in case of 304 Not modified
+    |> List.map (readCache >> parseFeedResult appCtx.Logger) // read from cache in case of 304 Not modified
     |> List.collect checkIfDiscoveryFeeds
     |> List.map readCache // read discovered feeds from cache
-    |> fetchAllRssFeeds ctx.Client ctx.Logger ctx.CacheConfig UserFetchConfig
+    |> fetchAllRssFeeds appCtx.Client appCtx.Logger appCtx.CacheConfig UserFetchConfig
     |> Async.RunSynchronously
     |> List.map (
         readCache // previous fetch can contain 304s
-        >> parseFeedResult ctx.Logger
-        >> cacheSuccessfulFetch ctx.CacheConfig
+        >> parseFeedResult appCtx.Logger
+        >> cacheSuccessfulFetch appCtx.CacheConfig
     )
     |> logSuccessfulFeedRequestsAndParses logPath
-    |> List.map (feedToArticles >> updateMemoryCache ctx.MemCache)
+    |> List.map (feedToArticles >> updateMemoryCache appCtx.MemCache)
     |> List.collect onlyFeedArticles
 
 let getFeedUrlQuery articles =
@@ -98,19 +98,19 @@ let private redirectTo (context: HttpListenerContext) (url: string) =
 /// Streams a feeds page for the current request's own `?rss=` query, redirecting first
 /// if fetching/discovery normalized the feed list (e.g. stripped a scheme, followed a discovery link).
 let private streamFeedResponse
-    (ctx: AppContext)
-    (context: HttpListenerContext)
+    (appCtx: AppContext)
+    (httpCtx: HttpListenerContext)
     (shell: Html)
     (render: Query -> Article list -> Html)
     =
     async {
-        context.Response.SendChunked <- true
-        context.Response.ContentType <- "text/html"
-        do! writeChunk context shell
+        httpCtx.Response.SendChunked <- true
+        httpCtx.Response.ContentType <- "text/html"
+        do! writeChunk httpCtx shell
 
-        let articles = processRssRequest ctx RequestLogPath context.Request.Url.Query
+        let articles = processRssRequest appCtx RequestLogPath httpCtx.Request.Url.Query
 
-        let originalQuery = Query.Create context.Request.Url.Query
+        let originalQuery = Query.Create httpCtx.Request.Url.Query
         let processedQuery = buildProcessedQuery articles
 
         let content =
@@ -119,8 +119,8 @@ let private streamFeedResponse
             else
                 render processedQuery articles
 
-        do! writeChunk context content
-        context.Response.OutputStream.Close()
+        do! writeChunk httpCtx content
+        httpCtx.Response.OutputStream.Close()
     }
 
 /// Looks up a collection by its id, rendering a "not found" page for an invalid
@@ -175,63 +175,63 @@ let private handleUpdateCollection (context: HttpListenerContext) (collectionId:
     }
 
 let private handleViewCollection
-    (ctx: AppContext)
-    (context: HttpListenerContext)
+    (appCtx: AppContext)
+    (httpCtx: HttpListenerContext)
     (collectionId: CollectionId)
     (shell: Html)
     (content: Query -> Article list -> Html)
     =
-    loadCollectionOrNotFound context collectionId (fun feeds ->
+    loadCollectionOrNotFound httpCtx collectionId (fun feeds ->
         async {
             touch CollectionsDir collectionId
             let collQuery = Query.CreateWithKey("rss", feeds)
-            context.Response.SendChunked <- true
-            context.Response.ContentType <- "text/html"
+            httpCtx.Response.SendChunked <- true
+            httpCtx.Response.ContentType <- "text/html"
 
-            do! writeChunk context shell
+            do! writeChunk httpCtx shell
 
-            let articles = processRssRequest ctx RequestLogPath (string collQuery)
+            let articles = processRssRequest appCtx RequestLogPath (string collQuery)
 
-            do! writeChunk context (content collQuery articles)
-            context.Response.OutputStream.Close()
+            do! writeChunk httpCtx (content collQuery articles)
+            httpCtx.Response.OutputStream.Close()
         })
 
-let handleRequest (ctx: AppContext) (context: HttpListenerContext) =
+let handleRequest (appCtx: AppContext) (httpCtx: HttpListenerContext) =
     async {
-        ctx.Logger.LogDebug $"Received request {context.Request.Url}"
+        appCtx.Logger.LogDebug $"Received request {httpCtx.Request.Url}"
 
-        match context.Request.RawUrl with
-        | Prefix "/config.html" _ -> do! handleConfigPage context
+        match httpCtx.Request.RawUrl with
+        | Prefix "/config.html" _ -> do! handleConfigPage httpCtx
         | Prefix "/shuffle?rss=" _ ->
-            let query = Query.Create context.Request.Url.Query
+            let query = Query.Create httpCtx.Request.Url.Query
 
-            do! streamFeedResponse ctx context (shuffledFeedsPageShell query) shuffledFeedsPageContent
+            do! streamFeedResponse appCtx httpCtx (shuffledFeedsPageShell query) shuffledFeedsPageContent
         | Prefix "/?rss=" _ ->
-            let query = Query.Create context.Request.Url.Query
+            let query = Query.Create httpCtx.Request.Url.Query
 
-            do! streamFeedResponse ctx context (chronologicalFeedsPageShell query) chronologicalFeedsPageContent
-        | "/robots.txt" -> do! writeResponse context (File.ReadAllText(Path.Combine("site", "robots.txt")))
-        | "/sitemap.xml" -> do! writeResponse context (File.ReadAllText(Path.Combine("site", "sitemap.xml")))
-        | "/s" when context.Request.HttpMethod = "POST" -> do! handleCreateCollection context
-        | CollectionShuffleId collectionId when context.Request.HttpMethod = "GET" ->
+            do! streamFeedResponse appCtx httpCtx (chronologicalFeedsPageShell query) chronologicalFeedsPageContent
+        | "/robots.txt" -> do! writeResponse httpCtx (File.ReadAllText(Path.Combine("site", "robots.txt")))
+        | "/sitemap.xml" -> do! writeResponse httpCtx (File.ReadAllText(Path.Combine("site", "sitemap.xml")))
+        | "/s" when httpCtx.Request.HttpMethod = "POST" -> do! handleCreateCollection httpCtx
+        | CollectionShuffleId collectionId when httpCtx.Request.HttpMethod = "GET" ->
             do!
                 handleViewCollection
-                    ctx
-                    context
+                    appCtx
+                    httpCtx
                     collectionId
                     (collectionShuffledPageShell collectionId)
                     shuffledFeedsPageContent
-        | CollectionIdPath collectionId when context.Request.HttpMethod = "GET" ->
+        | CollectionIdPath collectionId when httpCtx.Request.HttpMethod = "GET" ->
             do!
                 handleViewCollection
-                    ctx
-                    context
+                    appCtx
+                    httpCtx
                     collectionId
                     (collectionFeedsPageShell collectionId)
                     chronologicalFeedsPageContent
-        | CollectionIdPath collectionId when context.Request.HttpMethod = "POST" ->
-            do! handleUpdateCollection context collectionId
-        | _ -> do! writeResponse context (landingPage |> string)
+        | CollectionIdPath collectionId when httpCtx.Request.HttpMethod = "POST" ->
+            do! handleUpdateCollection httpCtx collectionId
+        | _ -> do! writeResponse httpCtx (landingPage |> string)
     }
 
 let private getCacheAge (logger: ILogger) cacheConfig url =
@@ -250,29 +250,29 @@ let private getCacheAge (logger: ILogger) cacheConfig url =
     | Some modTime when (DateTimeOffset.Now - modTime) > cacheConfig.Expiration -> Some(PendingFetch(cacheAge, url))
     | _ -> None
 
-let updateCache (ctx: AppContext) (urls: Uri list) =
+let updateCache (appCtx: AppContext) (urls: Uri list) =
     if not (List.isEmpty urls) then
         urls
-        |> List.choose (getCacheAge ctx.Logger ctx.CacheConfig)
-        |> fetchAllRssFeeds ctx.Client ctx.Logger ctx.CacheConfig CacheRefreshFetchConfig
+        |> List.choose (getCacheAge appCtx.Logger appCtx.CacheConfig)
+        |> fetchAllRssFeeds appCtx.Client appCtx.Logger appCtx.CacheConfig CacheRefreshFetchConfig
         |> Async.RunSynchronously
         |> List.iter (
-            parseFeedResult ctx.Logger
-            >> cacheSuccessfulFetch ctx.CacheConfig
+            parseFeedResult appCtx.Logger
+            >> cacheSuccessfulFetch appCtx.CacheConfig
             >> feedToArticles
-            >> updateMemoryCache ctx.MemCache
+            >> updateMemoryCache appCtx.MemCache
             >> ignore
         )
 
 [<TailCall>]
-let rec updateRssFeedsPeriodically (ctx: AppContext) =
+let rec updateRssFeedsPeriodically (appCtx: AppContext) =
     async {
-        ctx.Logger.LogDebug "Periodically updating RSS feeds."
+        appCtx.Logger.LogDebug "Periodically updating RSS feeds."
 
-        uniqueValidRequestLogUrls RequestLogPath |> updateCache ctx
+        uniqueValidRequestLogUrls RequestLogPath |> updateCache appCtx
 
-        do! Async.Sleep ctx.CacheConfig.Expiration
-        return! updateRssFeedsPeriodically ctx
+        do! Async.Sleep appCtx.CacheConfig.Expiration
+        return! updateRssFeedsPeriodically appCtx
     }
 
 [<TailCall>]
@@ -286,20 +286,20 @@ let rec clearCachePeriodically (logger: ILogger) (cacheDir: OsPath) (retention: 
         return! clearCachePeriodically logger cacheDir retention period
     }
 
-let private handleRequestSafely (ctx: AppContext) context =
+let private handleRequestSafely (appCtx: AppContext) httpCtx =
     async {
         try
-            do! handleRequest ctx context
+            do! handleRequest appCtx httpCtx
         with ex ->
-            ctx.Logger.LogInformation("Request handling error: {Message}", ex.Message)
+            appCtx.Logger.LogInformation("Request handling error: {Message}", ex.Message)
     }
 
 [<TailCall>]
-let rec private serverLoop (listener: HttpListener) (ctx: AppContext) =
+let rec private serverLoop (listener: HttpListener) (appCtx: AppContext) =
     async {
-        let! context = listener.GetContextAsync() |> Async.AwaitTask
-        do! handleRequestSafely ctx context
-        return! serverLoop listener ctx
+        let! httpCtx = listener.GetContextAsync() |> Async.AwaitTask
+        do! handleRequestSafely appCtx httpCtx
+        return! serverLoop listener appCtx
     }
 
 let startServer (logger: ILogger) (cacheConfig: SimpleRssServer.Config.CacheConfig) (hosts: string list) =
@@ -311,18 +311,18 @@ let startServer (logger: ILogger) (cacheConfig: SimpleRssServer.Config.CacheConf
     let addresses = hosts |> String.concat ", "
     logger.LogInformation("Listening at {Addresses}", addresses)
 
-    let ctx =
+    let appCtx =
         { Client = new Http.HttpClient()
           Logger = logger
           CacheConfig = cacheConfig
           MemCache = InMemoryCache logger }
 
-    Async.Start(updateRssFeedsPeriodically ctx)
+    Async.Start(updateRssFeedsPeriodically appCtx)
 
     let cacheCleanupPeriod = TimeSpan.FromDays 1.0
     Async.Start(clearCachePeriodically logger cacheConfig.Dir CacheRetention cacheCleanupPeriod)
 
-    serverLoop listener ctx
+    serverLoop listener appCtx
 
 let helpMessage =
     """


### PR DESCRIPTION
## Summary
- Introduces an `AppContext` record (`Client`, `Logger`, `CacheConfig`, `MemCache`) built once in `startServer`, threaded through `processRssRequest`, `streamFeedResponse`, `handleViewCollection`, `updateCache`, `updateRssFeedsPeriodically`, `handleRequest`, `handleRequestSafely`, and `serverLoop`, cutting these functions down by 3 params each.
- Updates `ProgramTests.fs` call sites accordingly, adding a `makeCtx` test helper.

## Test plan
- [x] `dotnet build`
- [x] `dotnet test` (132/132 passing)
- [x] `dotnet fsharplint lint SimpleRssServer.sln` (0 warnings)
- [x] `dotnet fantomas .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)