### PR TITLE
Simplify --loglevel arg parsing with a lookup map

### DIFF
--- a/SimpleRssServer/ArgParser.fs
+++ b/SimpleRssServer/ArgParser.fs
@@ -11,33 +11,23 @@ type ParsedArgs =
     | Help
     | InvalidArgs of string
 
+let private logLevels =
+    Map
+        [ "debug", LogLevel.Debug
+          "info", LogLevel.Information
+          "warning", LogLevel.Warning
+          "error", LogLevel.Error ]
+
 [<TailCall>]
 let rec private parseArgs parts acc =
     match parts with
     | [] -> Args acc
     | "--help" :: _ -> Help
     | "--hostname" :: hostname :: rest -> parseArgs rest { acc with Hostname = Some hostname }
-    | "--loglevel" :: "debug" :: rest ->
-        parseArgs
-            rest
-            { acc with
-                LogLevel = Some LogLevel.Debug }
-    | "--loglevel" :: "info" :: rest ->
-        parseArgs
-            rest
-            { acc with
-                LogLevel = Some LogLevel.Information }
-    | "--loglevel" :: "warning" :: rest ->
-        parseArgs
-            rest
-            { acc with
-                LogLevel = Some LogLevel.Warning }
-    | "--loglevel" :: "error" :: rest ->
-        parseArgs
-            rest
-            { acc with
-                LogLevel = Some LogLevel.Error }
-    | "--loglevel" :: invalid :: _ -> InvalidArgs $"Log level {invalid} does not exist"
+    | "--loglevel" :: level :: rest ->
+        match logLevels.TryFind level with
+        | Some logLevel -> parseArgs rest { acc with LogLevel = Some logLevel }
+        | None -> InvalidArgs $"Log level {level} does not exist"
     | _ -> Args acc
 
 let parse (args: string) : ParsedArgs =


### PR DESCRIPTION
## Summary
- Collapses four near-identical `--loglevel` match cases in `ArgParser.fs` into a single case backed by a `Map`, since they differed only in the literal string and the `LogLevel` value.

## Test plan
- [x] `dotnet test` — all 132 tests pass