### PR TITLE
Share retention-age check between Cache.fs and Collections.fs

### DIFF
--- a/SimpleRssServer/Cache.fs
+++ b/SimpleRssServer/Cache.fs
@@ -114,10 +114,8 @@ let clearExpiredCache (logger: ILogger) (cacheDir: OsPath) (retention: TimeSpan)
     if not (OsDirectory.exists cacheDir) then
         logger.LogWarning("Cache directory {Dir} does not exist", cacheDir)
     else
-        let now = DateTime.Now
-
         OsDirectory.getFiles cacheDir
-        |> Array.filter (fun f -> (now - OsFile.getLastWriteTime f) > retention)
+        |> Array.filter (OsFile.isOlderThan retention)
         |> Array.iter OsFile.delete
 
 let private invalidFilenameCharsRegex =

--- a/SimpleRssServer/Collections.fs
+++ b/SimpleRssServer/Collections.fs
@@ -42,9 +42,7 @@ let delete (dir: OsPath) (collectionId: CollectionId) =
 
 let deleteInactive (dir: OsPath) (retention: TimeSpan) =
     if OsDirectory.exists dir then
-        let cutoff = DateTime.Now - retention
-
         OsDirectory.getFiles dir
         |> Array.filter (fun (OsPath p) -> p.EndsWith ".txt")
-        |> Array.filter (fun path -> OsFile.getLastWriteTime path < cutoff)
+        |> Array.filter (OsFile.isOlderThan retention)
         |> Array.iter OsFile.delete

--- a/SimpleRssServer/DomainPrimitiveTypes.fs
+++ b/SimpleRssServer/DomainPrimitiveTypes.fs
@@ -90,6 +90,9 @@ module OsFile =
     let readAllLines (OsPath path) = File.ReadAllLines path
     let readAllText (OsPath path) = File.ReadAllText path
 
+    let isOlderThan (retention: TimeSpan) (path: OsPath) =
+        getLastWriteTime path < DateTime.Now - retention
+
     let setLastWriteTime (OsPath path) lastWriteTime =
         File.SetLastWriteTime(path, lastWriteTime)
 


### PR DESCRIPTION
## Summary
- `Cache.fs`'s `clearExpiredCache` and `Collections.fs`'s `deleteInactive` both reimplemented "is this file older than retention" with slightly different phrasing (`now - lastWrite > retention` vs `lastWrite < cutoff`).
- Extracted a single `OsFile.isOlderThan` helper and reused it in both, while keeping each caller's own behavior (directory-existence warning in `Cache.fs`, `.txt`-extension filter in `Collections.fs`).

No behavior changes — pure internal cleanup.

## Test plan
- [x] `dotnet build` — no warnings
- [x] `dotnet test` — all 132 tests pass