### PR TITLE
Consolidate URL/query helper duplication

### DIFF
--- a/SimpleRssServer.Tests/DomainPrimitiveTypesTests.fs
+++ b/SimpleRssServer.Tests/DomainPrimitiveTypesTests.fs
@@ -65,15 +65,15 @@ let ``Uri.createWithHttps should return Error for invalid host`` () =
 
 [<Fact>]
 let ``Uri.StripScheme removes https scheme`` () =
-    Assert.Equal("example.com/feed", FeedUri.removeScheme "https://example.com/feed")
+    Assert.Equal("example.com/feed", FeedUri.removeSchemes "https://example.com/feed")
 
 [<Fact>]
 let ``Uri.StripScheme removes http scheme`` () =
-    Assert.Equal("example.com/feed", FeedUri.removeScheme "http://example.com/feed")
+    Assert.Equal("example.com/feed", FeedUri.removeSchemes "http://example.com/feed")
 
 [<Fact>]
 let ``Uri.StripScheme leaves url without scheme unchanged`` () =
-    Assert.Equal("example.com/feed", FeedUri.removeScheme "example.com/feed")
+    Assert.Equal("example.com/feed", FeedUri.removeSchemes "example.com/feed")
 
 [<Fact>]
 let ``Query.Create empty string gives empty ToString`` () =

--- a/SimpleRssServer.Tests/ProgramTests.fs
+++ b/SimpleRssServer.Tests/ProgramTests.fs
@@ -494,11 +494,11 @@ let ``processRssRequest returns processed query with discovered feed URL instead
     let articles =
         processRssRequest (makeCtx client cacheConfig memCache) (makeTempLogPath ()) $"?rss={htmlUrl}"
 
-    let queryUrls = getFeedUrlQuery articles |> fun x -> x.GetValues "rss"
+    let queryUrls = buildProcessedQuery articles |> fun x -> x.GetValues "rss"
 
     // Assert: processed query contains the feed URL, not the original page URL
     Assert.Equal(1, queryUrls.Length)
-    Assert.Equal(feedUrl, queryUrls[0])
+    Assert.Equal(FeedUri.removeHttpsScheme feedUrl, queryUrls[0])
     Assert.Equal(Some articles, memCache.TryGet(feedUrl, cacheConfig.Expiration))
 
 [<Fact>]

--- a/SimpleRssServer/DomainPrimitiveTypes.fs
+++ b/SimpleRssServer/DomainPrimitiveTypes.fs
@@ -42,7 +42,7 @@ module FeedUri =
         else
             s
 
-    let removeScheme (s: string) =
+    let removeSchemes (s: string) =
         let s = removeHttpsScheme s
 
         if s.StartsWith("http://", StringComparison.OrdinalIgnoreCase) then

--- a/SimpleRssServer/DomainPrimitiveTypes.fs
+++ b/SimpleRssServer/DomainPrimitiveTypes.fs
@@ -36,13 +36,17 @@ module FeedUri =
         with _ ->
             ""
 
-    let removeScheme (s: string) =
-        let s = s.Replace("http://", "")
-        s.Replace("https://", "")
-
     let removeHttpsScheme (s: string) =
         if s.StartsWith("https://", StringComparison.OrdinalIgnoreCase) then
             s.Substring 8
+        else
+            s
+
+    let removeScheme (s: string) =
+        let s = removeHttpsScheme s
+
+        if s.StartsWith("http://", StringComparison.OrdinalIgnoreCase) then
+            s.Substring 7
         else
             s
 

--- a/SimpleRssServer/HtmlRenderer.fs
+++ b/SimpleRssServer/HtmlRenderer.fs
@@ -9,11 +9,11 @@ open DomainPrimitiveTypes
 open SimpleRssServer.DomainModel
 
 let removeFromQuery (query: Query) (feedToRemove: string) : string =
-    let normalizedFeedUrl = FeedUri.removeScheme feedToRemove
+    let normalizedFeedUrl = FeedUri.removeSchemes feedToRemove
 
     let remaining =
         query.Value.GetValues "rss"
-        |> Array.filter (fun u -> FeedUri.removeScheme u <> normalizedFeedUrl)
+        |> Array.filter (fun u -> FeedUri.removeSchemes u <> normalizedFeedUrl)
         |> Array.toList
 
     match Query.CreateWithKey("rss", remaining) |> string with
@@ -29,7 +29,7 @@ let private deleteFeedButton (query: Query) (feedUrl: string) : Html =
     let removeUrl = removeFromQuery query feedUrl
 
     $"""<button class="remove-feed"
-            title="Remove {feedUrl |> FeedUri.removeScheme} from your feed"
+            title="Remove {feedUrl |> FeedUri.removeSchemes} from your feed"
             onclick="removeFeed('{removeUrl}', '{feedUrl}')">{trashIcon}</button>"""
     |> Html
 

--- a/SimpleRssServer/HtmlRenderer.fs
+++ b/SimpleRssServer/HtmlRenderer.fs
@@ -14,11 +14,11 @@ let removeFromQuery (query: Query) (feedToRemove: string) : string =
     let remaining =
         query.Value.GetValues "rss"
         |> Array.filter (fun u -> FeedUri.removeScheme u <> normalizedFeedUrl)
+        |> Array.toList
 
-    if remaining.Length = 0 then
-        "/"
-    else
-        "?" + (remaining |> Array.map (fun u -> $"rss={u}") |> String.concat "&")
+    match Query.CreateWithKey("rss", remaining) |> string with
+    | "" -> "/"
+    | q -> q
 
 let head: Html = File.ReadAllText(Path.Combine("site", "head.html")) |> Html
 

--- a/SimpleRssServer/Program.fs
+++ b/SimpleRssServer/Program.fs
@@ -51,12 +51,6 @@ let processRssRequest (appCtx: AppContext) (logPath: OsPath) (query: string) =
     |> List.map (feedToArticles >> updateMemoryCache appCtx.MemCache)
     |> List.collect onlyFeedArticles
 
-let getFeedUrlQuery articles =
-    articles
-    |> List.map _.FeedUrl
-    |> List.distinct
-    |> fun u -> Query.CreateWithKey("rss", u)
-
 let buildProcessedQuery (articles: Article list) : Query =
     articles
     |> List.map (fun a -> FeedUri.removeHttpsScheme a.FeedUrl)


### PR DESCRIPTION
## Summary
- `removeFromQuery` (`HtmlRenderer.fs`) hand-built the query string via string concatenation instead of reusing `Query.CreateWithKey` + `ToString()`.
- `removeScheme` and `removeHttpsScheme` (`DomainPrimitiveTypes.fs`) implemented the same "strip scheme" intent two different ways: `removeScheme` used `Replace`, which strips `http://`/`https://` wherever they occur in the string (could corrupt a URL with a query param containing `https://`), while `removeHttpsScheme` correctly strips only a leading `https://`. `removeScheme` now composes `removeHttpsScheme` and applies the same prefix-safe check for `http://`, fixing the mid-string bug as a side effect of de-duplicating.
- Removed `getFeedUrlQuery`, a near-duplicate of `buildProcessedQuery` that wasn't called from any production code path (only from one test). That test now uses `buildProcessedQuery` directly, with its assertion adjusted for the scheme-stripping difference.

## Test plan
- [x] `dotnet build` — no warnings
- [x] `dotnet test` — all 132 tests pass