### PR TITLE
Extract pure parseRoute from handleRequest

### DIFF
--- a/SimpleRssServer.Tests/ProgramTests.fs
+++ b/SimpleRssServer.Tests/ProgramTests.fs
@@ -834,7 +834,7 @@ let getSortedQueryUrls (q: Query) = q.GetValues "rss" |> List.sort
 
 // Scenario 1: user enters example.com/feed (no scheme) → stored as example.com/feed, no redirect
 [<Fact>]
-let ``handleRequest keeps no-scheme url in query and does not redirect`` () =
+let ``buildProcessedQuery keeps no-scheme url in query so no redirect is triggered`` () =
     let articles = [ makeArticle "https://example.com/feed" ]
     let originalQuery = Query.Create "?rss=example.com/feed"
     let processedQuery = buildProcessedQuery articles
@@ -843,7 +843,7 @@ let ``handleRequest keeps no-scheme url in query and does not redirect`` () =
 
 // Scenario 2: user enters http://example.com/feed → stored as http://example.com/feed, no redirect
 [<Fact>]
-let ``handleRequest keeps http scheme in query and does not redirect`` () =
+let ``buildProcessedQuery keeps http scheme in query so no redirect is triggered`` () =
     let articles = [ makeArticle "http://example.com/feed" ]
     let originalQuery = Query.Create "?rss=http://example.com/feed"
     let processedQuery = buildProcessedQuery articles
@@ -852,7 +852,7 @@ let ``handleRequest keeps http scheme in query and does not redirect`` () =
 
 // Scenario 3: user enters https://example.com/feed → stripped to example.com/feed via redirect
 [<Fact>]
-let ``handleRequest strips https scheme from query via redirect`` () =
+let ``buildProcessedQuery strips https scheme from query so a redirect is triggered`` () =
     let articles = [ makeArticle "https://example.com/feed" ]
     let originalQuery = Query.Create "?rss=https://example.com/feed"
     let processedQuery = buildProcessedQuery articles
@@ -861,7 +861,7 @@ let ``handleRequest strips https scheme from query via redirect`` () =
 
 // Scenario 4: user enters example.com/ → discovery finds https://example.com/feed → redirect to example.com/feed
 [<Fact>]
-let ``handleRequest strips https from discovered feed url in redirect`` () =
+let ``buildProcessedQuery strips https from a discovered feed url`` () =
     let pagePath = $"example.com/page/{Guid.NewGuid()}"
     let htmlUrl = $"https://{pagePath}"
     let feedGuid = Guid.NewGuid()
@@ -895,7 +895,7 @@ let ``handleRequest strips https from discovered feed url in redirect`` () =
 
 // Scenario 5: user enters example.com/ → discovery finds http://example.com/feed → redirect to http://example.com/feed
 [<Fact>]
-let ``handleRequest keeps http scheme for discovered feed url in redirect`` () =
+let ``buildProcessedQuery keeps http scheme for a discovered feed url`` () =
     let pagePath = $"example.com/page/{Guid.NewGuid()}"
     let htmlUrl = $"https://{pagePath}"
     let feedGuid = Guid.NewGuid()

--- a/SimpleRssServer.Tests/RouterTests.fs
+++ b/SimpleRssServer.Tests/RouterTests.fs
@@ -1,0 +1,92 @@
+module SimpleRssServer.Tests.RouterTests
+
+open Xunit
+
+open SimpleRssServer.DomainPrimitiveTypes
+open SimpleRssServer.Router
+
+[<Fact>]
+let ``config.html routes to ConfigPage`` () =
+    Assert.Equal(ConfigPage, parseRoute "GET" "/config.html")
+
+[<Fact>]
+let ``config.html with a collection query routes to ConfigPage`` () =
+    Assert.Equal(ConfigPage, parseRoute "GET" "/config.html?s=abc123")
+
+[<Fact>]
+let ``config.html with a feed query routes to ConfigPage`` () =
+    Assert.Equal(ConfigPage, parseRoute "GET" "/config.html/?rss=example.com/feed")
+
+[<Fact>]
+let ``root with rss query routes to ChronologicalFeeds`` () =
+    Assert.Equal(ChronologicalFeeds, parseRoute "GET" "/?rss=example.com/feed")
+
+[<Fact>]
+let ``shuffle with rss query routes to ShuffleFeeds`` () =
+    Assert.Equal(ShuffleFeeds, parseRoute "GET" "/shuffle?rss=example.com/feed")
+
+[<Fact>]
+let ``robots.txt routes to RobotsTxt`` () =
+    Assert.Equal(RobotsTxt, parseRoute "GET" "/robots.txt")
+
+[<Fact>]
+let ``sitemap.xml routes to SitemapXml`` () =
+    Assert.Equal(SitemapXml, parseRoute "GET" "/sitemap.xml")
+
+[<Fact>]
+let ``POST /s routes to CreateCollection`` () =
+    Assert.Equal(CreateCollection, parseRoute "POST" "/s")
+
+[<Fact>]
+let ``GET /s routes to LandingPage`` () =
+    Assert.Equal(LandingPage, parseRoute "GET" "/s")
+
+[<Fact>]
+let ``GET a collection path routes to ViewCollection`` () =
+    Assert.Equal(ViewCollection(CollectionId "abc123"), parseRoute "GET" "/s/abc123")
+
+[<Fact>]
+let ``GET a collection path with a query strips the query from the id`` () =
+    Assert.Equal(ViewCollection(CollectionId "abc123"), parseRoute "GET" "/s/abc123?foo=bar")
+
+[<Fact>]
+let ``GET a collection shuffle path routes to ViewCollectionShuffle, not ViewCollection`` () =
+    Assert.Equal(ViewCollectionShuffle(CollectionId "abc123"), parseRoute "GET" "/s/abc123/shuffle")
+
+[<Fact>]
+let ``GET a collection shuffle path with a query strips the query from the id`` () =
+    Assert.Equal(ViewCollectionShuffle(CollectionId "abc123"), parseRoute "GET" "/s/abc123/shuffle?foo=bar")
+
+[<Fact>]
+let ``POST a collection path routes to UpdateCollection`` () =
+    Assert.Equal(UpdateCollection(CollectionId "abc123"), parseRoute "POST" "/s/abc123")
+
+[<Fact>]
+let ``POST a collection shuffle path falls through to UpdateCollection with the raw id`` () =
+    // CollectionShuffleId only matches GET, so POST is handled by the collection-id arm.
+    Assert.Equal(UpdateCollection(CollectionId "abc123/shuffle"), parseRoute "POST" "/s/abc123/shuffle")
+
+[<Fact>]
+let ``DELETE a collection path routes to LandingPage`` () =
+    Assert.Equal(LandingPage, parseRoute "DELETE" "/s/abc123")
+
+[<Fact>]
+let ``an id with invalid characters still routes to ViewCollection`` () =
+    // Validation happens in the handler, not the router.
+    Assert.Equal(ViewCollection(CollectionId "../etc/passwd"), parseRoute "GET" "/s/../etc/passwd")
+
+[<Fact>]
+let ``root without a query routes to LandingPage`` () =
+    Assert.Equal(LandingPage, parseRoute "GET" "/")
+
+[<Fact>]
+let ``root with a non-rss query routes to LandingPage`` () =
+    Assert.Equal(LandingPage, parseRoute "GET" "/?foo=bar")
+
+[<Fact>]
+let ``bare shuffle without an rss query routes to LandingPage`` () =
+    Assert.Equal(LandingPage, parseRoute "GET" "/shuffle")
+
+[<Fact>]
+let ``an unknown path routes to LandingPage`` () =
+    Assert.Equal(LandingPage, parseRoute "GET" "/nonsense")

--- a/SimpleRssServer.Tests/SimpleRssServer.Tests.fsproj
+++ b/SimpleRssServer.Tests/SimpleRssServer.Tests.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="CacheTests.fs" />
     <Compile Include="HtmlRendererTests.fs" />
     <Compile Include="RequestLogTests.fs" />
+    <Compile Include="RouterTests.fs" />
     <Compile Include="ProgramTests.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/SimpleRssServer/Program.fs
+++ b/SimpleRssServer/Program.fs
@@ -13,6 +13,7 @@ open SimpleRssServer.Logging
 open SimpleRssServer.MemoryCache
 open SimpleRssServer.Request
 open SimpleRssServer.RequestLog
+open SimpleRssServer.Router
 open SimpleRssServer.RssParser
 open SimpleRssServer.DomainModel
 open SimpleRssServer.DomainPrimitiveTypes
@@ -197,20 +198,20 @@ let handleRequest (appCtx: AppContext) (httpCtx: HttpListenerContext) =
     async {
         appCtx.Logger.LogDebug $"Received request {httpCtx.Request.Url}"
 
-        match httpCtx.Request.RawUrl with
-        | Prefix "/config.html" _ -> do! handleConfigPage httpCtx
-        | Prefix "/shuffle?rss=" _ ->
+        match parseRoute httpCtx.Request.HttpMethod httpCtx.Request.RawUrl with
+        | ConfigPage -> do! handleConfigPage httpCtx
+        | ShuffleFeeds ->
             let query = Query.Create httpCtx.Request.Url.Query
 
             do! streamFeedResponse appCtx httpCtx (shuffledFeedsPageShell query) shuffledFeedsPageContent
-        | Prefix "/?rss=" _ ->
+        | ChronologicalFeeds ->
             let query = Query.Create httpCtx.Request.Url.Query
 
             do! streamFeedResponse appCtx httpCtx (chronologicalFeedsPageShell query) chronologicalFeedsPageContent
-        | "/robots.txt" -> do! writeResponse httpCtx robotsTxt
-        | "/sitemap.xml" -> do! writeResponse httpCtx sitemapXml
-        | "/s" when httpCtx.Request.HttpMethod = "POST" -> do! handleCreateCollection httpCtx
-        | CollectionShuffleId collectionId when httpCtx.Request.HttpMethod = "GET" ->
+        | RobotsTxt -> do! writeResponse httpCtx robotsTxt
+        | SitemapXml -> do! writeResponse httpCtx sitemapXml
+        | CreateCollection -> do! handleCreateCollection httpCtx
+        | ViewCollectionShuffle collectionId ->
             do!
                 handleViewCollection
                     appCtx
@@ -218,7 +219,7 @@ let handleRequest (appCtx: AppContext) (httpCtx: HttpListenerContext) =
                     collectionId
                     (collectionShuffledPageShell collectionId)
                     shuffledFeedsPageContent
-        | CollectionIdPath collectionId when httpCtx.Request.HttpMethod = "GET" ->
+        | ViewCollection collectionId ->
             do!
                 handleViewCollection
                     appCtx
@@ -226,9 +227,8 @@ let handleRequest (appCtx: AppContext) (httpCtx: HttpListenerContext) =
                     collectionId
                     (collectionFeedsPageShell collectionId)
                     chronologicalFeedsPageContent
-        | CollectionIdPath collectionId when httpCtx.Request.HttpMethod = "POST" ->
-            do! handleUpdateCollection httpCtx collectionId
-        | _ -> do! writeResponse httpCtx (landingPage |> string)
+        | UpdateCollection collectionId -> do! handleUpdateCollection httpCtx collectionId
+        | LandingPage -> do! writeResponse httpCtx (landingPage |> string)
     }
 
 let private getCacheAge (logger: ILogger) cacheConfig url =

--- a/SimpleRssServer/Router.fs
+++ b/SimpleRssServer/Router.fs
@@ -1,0 +1,34 @@
+module SimpleRssServer.Router
+
+open SimpleRssServer.DomainPrimitiveTypes
+open SimpleRssServer.Helper
+
+/// A resolved request target. Parsing the HTTP method and raw URL into this DU keeps
+/// the routing decision separate from the IO each handler performs, so the dispatch
+/// table can be tested without an HttpListener.
+type Route =
+    | ConfigPage
+    | ChronologicalFeeds
+    | ShuffleFeeds
+    | RobotsTxt
+    | SitemapXml
+    | CreateCollection
+    | ViewCollection of CollectionId
+    | ViewCollectionShuffle of CollectionId
+    | UpdateCollection of CollectionId
+    | LandingPage
+
+/// Collection-id validation is deliberately not done here; an id that parses as
+/// `ViewCollection`/`UpdateCollection` may still be rejected by the handler.
+let parseRoute (method: string) (rawUrl: string) : Route =
+    match rawUrl with
+    | Prefix "/config.html" _ -> ConfigPage
+    | Prefix "/shuffle?rss=" _ -> ShuffleFeeds
+    | Prefix "/?rss=" _ -> ChronologicalFeeds
+    | "/robots.txt" -> RobotsTxt
+    | "/sitemap.xml" -> SitemapXml
+    | "/s" when method = "POST" -> CreateCollection
+    | CollectionShuffleId collectionId when method = "GET" -> ViewCollectionShuffle collectionId
+    | CollectionIdPath collectionId when method = "GET" -> ViewCollection collectionId
+    | CollectionIdPath collectionId when method = "POST" -> UpdateCollection collectionId
+    | _ -> LandingPage

--- a/SimpleRssServer/SimpleRssServer.fsproj
+++ b/SimpleRssServer/SimpleRssServer.fsproj
@@ -8,6 +8,7 @@
     <Compile Include="DomainModel.fs" />
     <Compile Include="Config.fs" />
     <Compile Include="Helper.fs" />
+    <Compile Include="Router.fs" />
     <Compile Include="Logging.fs" />
     <Compile Include="HttpClient.fs" />
     <Compile Include="MemoryCache.fs" />


### PR DESCRIPTION
Starts closing the test gap around HTTP routing (`handleRequest` had no coverage).

- **`Router.fs`** (new): `Route` DU + pure `parseRoute method rawUrl` — the routing `match` lifted out of `handleRequest` unchanged (same arm order, patterns, method guards). Id validation stays in the handlers.
- **`Program.fs`**: `handleRequest` matches on `Route` and dispatches to the unchanged handlers. Behavior-preserving.
- **`RouterTests.fs`** (new, 21 tests): full dispatch table incl. method gating, `/s/<id>/shuffle` precedence, query stripping, `LandingPage` fall-throughs.
- **`ProgramTests.fs`**: renamed 5 misnamed `handleRequest …` tests to `buildProcessedQuery …`.

`dotnet test` 153 passed · fantomas clean · fsharplint 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)