### PR TITLE
Table-test computeCacheAndBackoffState

### DIFF
--- a/SimpleRssServer.Tests/RequestTests.fs
+++ b/SimpleRssServer.Tests/RequestTests.fs
@@ -61,3 +61,50 @@ let ``Test getRssUrls adds https if missing`` () =
         [ Ok(Uri "https://example.com/feed"); Ok(Uri "http://example.com/feed2") ]
 
     Assert.Equal<Result<Uri, UriError> list>(expected, result)
+
+// computeCacheAndBackoffState: cacheModified = when the cache file was written (None = no cache),
+// nextAttempt = next allowed retry from backoff (None = no failure record).
+
+let private oneHour = TimeSpan.FromHours 1.0
+
+[<Fact>]
+let ``computeCacheAndBackoffState: no cache and no failures`` () =
+    Assert.Equal(NoCacheNoFailures, computeCacheAndBackoffState None None oneHour)
+
+[<Fact>]
+let ``computeCacheAndBackoffState: fresh cache and no failures is a cache hit`` () =
+    let cacheModified = Some(DateTimeOffset.Now.AddMinutes -30.0)
+    Assert.Equal(CacheHit, computeCacheAndBackoffState cacheModified None oneHour)
+
+[<Fact>]
+let ``computeCacheAndBackoffState: stale cache and no failures is expired`` () =
+    let cacheModified = Some(DateTimeOffset.Now.AddHours -2.0)
+    Assert.Equal(CacheExpired, computeCacheAndBackoffState cacheModified None oneHour)
+
+[<Fact>]
+let ``computeCacheAndBackoffState: elapsed backoff is ready to retry`` () =
+    let nextAttempt = Some(DateTimeOffset.Now.AddHours -1.0)
+    Assert.Equal(ReadyToRetry, computeCacheAndBackoffState None nextAttempt oneHour)
+
+[<Fact>]
+let ``computeCacheAndBackoffState: an elapsed backoff wins over a stale cache`` () =
+    let cacheModified = Some(DateTimeOffset.Now.AddHours -5.0)
+    let nextAttempt = Some(DateTimeOffset.Now.AddHours -1.0)
+    Assert.Equal(ReadyToRetry, computeCacheAndBackoffState cacheModified nextAttempt oneHour)
+
+[<Fact>]
+let ``computeCacheAndBackoffState: active backoff with a cache reports the wait time`` () =
+    let cacheModified = Some(DateTimeOffset.Now.AddMinutes -30.0)
+    let nextAttempt = Some(DateTimeOffset.Now.AddHours 2.0)
+
+    match computeCacheAndBackoffState cacheModified nextAttempt oneHour with
+    | InBackoffWithCache waitTime -> Assert.True(abs (waitTime.TotalHours - 2.0) < 0.1)
+    | other -> Assert.Fail $"expected InBackoffWithCache, got {other}"
+
+[<Fact>]
+let ``computeCacheAndBackoffState: active backoff without a cache reports the wait time`` () =
+    let nextAttempt = Some(DateTimeOffset.Now.AddHours 2.0)
+
+    match computeCacheAndBackoffState None nextAttempt oneHour with
+    | InBackoffNoCache waitTime -> Assert.True(abs (waitTime.TotalHours - 2.0) < 0.1)
+    | other -> Assert.Fail $"expected InBackoffNoCache, got {other}"


### PR DESCRIPTION
Next item from the testing backlog. `Request.computeCacheAndBackoffState` is a pure decision function with 6 `CacheState` outcomes and order-dependent match arms, but was only covered transitively through `processRssRequest`.

Adds 7 direct tests to `RequestTests.fs`:
- each of the 6 outcomes (`NoCacheNoFailures`, `CacheHit`, `CacheExpired`, `ReadyToRetry`, `InBackoffWithCache`, `InBackoffNoCache`)
- the `ReadyToRetry`-beats-`CacheExpired` precedence when both a stale cache and an elapsed backoff exist
- the reported wait time for the two in-backoff cases

`dotnet test` 177 passed · fantomas clean · fsharplint 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)