### PR TITLE
Remove unused Collections.delete

### DIFF
--- a/SimpleRssServer.Tests/CollectionsTests.fs
+++ b/SimpleRssServer.Tests/CollectionsTests.fs
@@ -63,21 +63,6 @@ let ``touch updates last-write-time`` () =
     Assert.True(OsFile.getLastWriteTime path > before)
 
 [<Fact>]
-let ``delete removes the file`` () =
-    use dir = new TempDir()
-    let collectionId = CollectionId "testcode3"
-    save dir.Path collectionId [ "example.com/feed" ]
-
-    delete dir.Path collectionId
-
-    Assert.False(OsFile.exists (OsPath.join dir.Path "testcode3.txt"))
-
-[<Fact>]
-let ``delete is no-op for missing file`` () =
-    use dir = new TempDir()
-    delete dir.Path (CollectionId "nonexistent")
-
-[<Fact>]
 let ``deleteInactive removes files past retention`` () =
     use dir = new TempDir()
     let collectionId = CollectionId "oldfile"

--- a/SimpleRssServer/Collections.fs
+++ b/SimpleRssServer/Collections.fs
@@ -34,12 +34,6 @@ let tryLoad (dir: OsPath) (collectionId: CollectionId) : string list option =
 let touch (dir: OsPath) (collectionId: CollectionId) =
     OsFile.setLastWriteTime (collectionFilePath dir collectionId) DateTime.Now
 
-let delete (dir: OsPath) (collectionId: CollectionId) =
-    let path = collectionFilePath dir collectionId
-
-    if OsFile.exists path then
-        OsFile.delete path
-
 let deleteInactive (dir: OsPath) (retention: TimeSpan) =
     if OsDirectory.exists dir then
         OsDirectory.getFiles dir


### PR DESCRIPTION
`Collections.delete` (single-collection delete) was never wired to a route, and per the owner it isn't wanted — collections auto-expire via `deleteInactive` (90-day `CollectionRetention`, reset by `touch` on every view).

Removes the function and its two unit tests. `deleteInactive` and the daily retention cleanup in `clearCachePeriodically` are unchanged.

`dotnet test` 175 passed · fantomas clean · fsharplint 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)