### PR TITLE
Replace FetchFailure.IsTimeout bool with a Kind DU

### DIFF
--- a/SimpleRssServer.Tests/CacheTests.fs
+++ b/SimpleRssServer.Tests/CacheTests.fs
@@ -19,7 +19,7 @@ let ``Test clearFailure deletes failure record`` () =
     let failure =
         { LastFailure = DateTimeOffset.Now
           ConsecutiveFailures = 2
-          IsTimeout = false }
+          Kind = FetchFailureKind.HttpError }
 
     let json = JsonSerializer.Serialize failure
     OsFile.writeAllText failurePath json
@@ -59,7 +59,7 @@ let ``Test get retry periods from failure file`` () =
     let failure1 =
         { LastFailure = DateTimeOffset.Now.AddMinutes -30.0
           ConsecutiveFailures = 1
-          IsTimeout = false }
+          Kind = FetchFailureKind.HttpError }
 
     let json1 = JsonSerializer.Serialize failure1
     OsFile.writeAllText failurePath json1
@@ -73,7 +73,7 @@ let ``Test get retry periods from failure file`` () =
     let failure2 =
         { LastFailure = DateTimeOffset.Now.AddHours -2.0
           ConsecutiveFailures = 1
-          IsTimeout = false }
+          Kind = FetchFailureKind.HttpError }
 
     let json2 = JsonSerializer.Serialize failure2
     OsFile.writeAllText failurePath json2
@@ -162,7 +162,7 @@ let ``Test clearExpiredCache also removes failure files`` () =
     let failure =
         { LastFailure = DateTimeOffset.Now.AddDays -10.0
           ConsecutiveFailures = 3
-          IsTimeout = false }
+          Kind = FetchFailureKind.HttpError }
 
     let json = JsonSerializer.Serialize failure
     OsFile.writeAllText failureFile json
@@ -217,7 +217,7 @@ let ``Test recordFailure resets count when failure kind switches`` () =
         JsonSerializer.Deserialize<FetchFailure>(OsFile.readAllText failurePath)
 
     Assert.Equal(1, afterSwitch.ConsecutiveFailures)
-    Assert.True(afterSwitch.IsTimeout)
+    Assert.Equal(FetchFailureKind.Timeout, afterSwitch.Kind)
 
 [<Fact>]
 let ``Test recordFailure resets count when switching from timeout to http error`` () =
@@ -238,7 +238,7 @@ let ``Test recordFailure resets count when switching from timeout to http error`
         JsonSerializer.Deserialize<FetchFailure>(OsFile.readAllText failurePath)
 
     Assert.Equal(1, afterSwitch.ConsecutiveFailures)
-    Assert.False(afterSwitch.IsTimeout)
+    Assert.Equal(FetchFailureKind.HttpError, afterSwitch.Kind)
 
 [<Fact>]
 let ``Test getTimeoutBackoffMinutes follows doubling pattern and caps`` () =
@@ -254,7 +254,7 @@ let ``Test nextRetry uses short backoff for timeout failure`` () =
     let failure =
         { LastFailure = DateTimeOffset.Now.AddMinutes -3.0
           ConsecutiveFailures = 1
-          IsTimeout = true }
+          Kind = FetchFailureKind.Timeout }
 
     OsFile.writeAllText failurePath (JsonSerializer.Serialize failure)
 
@@ -270,7 +270,7 @@ let ``Test nextRetry uses long backoff for http error failure`` () =
     let failure =
         { LastFailure = DateTimeOffset.Now.AddMinutes -30.0
           ConsecutiveFailures = 1
-          IsTimeout = false }
+          Kind = FetchFailureKind.HttpError }
 
     OsFile.writeAllText failurePath (JsonSerializer.Serialize failure)
 
@@ -278,13 +278,17 @@ let ``Test nextRetry uses long backoff for http error failure`` () =
     | Some d -> Assert.True(d > DateTimeOffset.Now, "1 h http error backoff should not have elapsed after 30 min")
     | None -> failwithf $"No failure file found at {failurePath}"
 
-[<Fact>]
-let ``Test nextRetry uses long backoff for legacy file without IsTimeout`` () =
+[<Theory>]
+// Pre-Kind file with no failure-kind field at all
+[<InlineData("""{"LastFailure":"{TS}","ConsecutiveFailures":1}""")>]
+// Pre-Kind file still carrying the old IsTimeout flag
+[<InlineData("""{"LastFailure":"{TS}","ConsecutiveFailures":1,"IsTimeout":true}""")>]
+let ``Test nextRetry falls back to long backoff for legacy file without Kind`` (template: string) =
     use tmp = new TempPath()
     let failurePath = failureFilePath tmp.Path
 
     let recentTimestamp = DateTimeOffset.Now.AddMinutes(-30.0).ToString("o")
-    OsFile.writeAllText failurePath $"""{{"LastFailure":"{recentTimestamp}","ConsecutiveFailures":1}}"""
+    OsFile.writeAllText failurePath (template.Replace("{TS}", recentTimestamp))
 
     match nextRetry NullLogger.Instance tmp.Path with
     | Some d -> Assert.True(d > DateTimeOffset.Now, "Legacy file should fall back to long backoff")

--- a/SimpleRssServer.Tests/ProgramTests.fs
+++ b/SimpleRssServer.Tests/ProgramTests.fs
@@ -132,7 +132,7 @@ let ``processRssRequest clears failure file when HTTP returns 304`` () =
     let failure =
         { LastFailure = DateTimeOffset.Now.AddHours -3.0
           ConsecutiveFailures = 2
-          IsTimeout = false }
+          Kind = FetchFailureKind.HttpError }
 
     OsFile.writeAllText (failureFilePath cachePath) (System.Text.Json.JsonSerializer.Serialize failure)
 
@@ -374,7 +374,7 @@ let ``processRssRequest retries and clears failure file when backoff period has 
     let failure =
         { LastFailure = DateTimeOffset.Now.AddHours -3.0
           ConsecutiveFailures = 2
-          IsTimeout = false }
+          Kind = FetchFailureKind.HttpError }
 
     OsFile.writeAllText (failureFilePath cachePath) (JsonSerializer.Serialize failure)
 

--- a/SimpleRssServer/Cache.fs
+++ b/SimpleRssServer/Cache.fs
@@ -5,16 +5,38 @@ open System
 open System.IO
 open System.Text
 open System.Text.Json
+open System.Text.Json.Serialization
 
 open SimpleRssServer.Config
 open SimpleRssServer.DomainModel
 open SimpleRssServer.DomainPrimitiveTypes
 open SimpleRssServer.MemoryCache
 
+[<JsonConverter(typeof<FetchFailureKindConverter>)>]
+[<Struct>]
+type FetchFailureKind =
+    | HttpError
+    | Timeout
+
+and private FetchFailureKindConverter() =
+    inherit JsonConverter<FetchFailureKind>()
+
+    override _.Read(reader, _, _) =
+        match reader.GetString() with
+        | "Timeout" -> Timeout
+        | _ -> HttpError
+
+    override _.Write(writer, value, _) =
+        writer.WriteStringValue(
+            match value with
+            | HttpError -> "HttpError"
+            | Timeout -> "Timeout"
+        )
+
 type FetchFailure =
     { LastFailure: DateTimeOffset
       ConsecutiveFailures: int
-      IsTimeout: bool }
+      Kind: FetchFailureKind }
 
 let failureFilePath (cachePath: OsPath) = cachePath + ".failures"
 
@@ -57,58 +79,47 @@ let clearFailure cachePath =
     if OsFile.exists failurePath then
         OsFile.delete failurePath
 
-let private freshFailure (isTimeout: bool) =
-    { LastFailure = DateTimeOffset.Now
-      ConsecutiveFailures = 1
-      IsTimeout = isTimeout }
-
-let private recordFailure (logger: ILogger) cachePath (isTimeout: bool) =
+let readFailureRecord (logger: ILogger) cachePath : FetchFailure option =
     let failurePath = failureFilePath cachePath
-    createDirectoryForPath failurePath
 
-    let failure =
-        if OsFile.exists failurePath then
-            try
-                let json = OsFile.readAllText failurePath
-                let existing = JsonSerializer.Deserialize<FetchFailure> json
-
-                if existing.IsTimeout = isTimeout then
-                    { existing with
-                        LastFailure = DateTimeOffset.Now
-                        ConsecutiveFailures = existing.ConsecutiveFailures + 1 }
-                else
-                    freshFailure isTimeout
-            with ex ->
-                logger.LogWarning(ex, "Failed to read existing failure record at {Path}, resetting count", failurePath)
-                freshFailure isTimeout
-        else
-            freshFailure isTimeout
-
-    OsFile.writeAllText failurePath (JsonSerializer.Serialize failure)
-
-let recordHttpFailure (logger: ILogger) cachePath = recordFailure logger cachePath false
-let recordTimeoutFailure (logger: ILogger) cachePath = recordFailure logger cachePath true
-
-let readFailure (logger: ILogger) cachePath =
-    let path = failureFilePath cachePath
-
-    if OsFile.exists path then
+    if OsFile.exists failurePath then
         try
-            let json = OsFile.readAllText path
-            Some(JsonSerializer.Deserialize<FetchFailure> json)
+            Some(JsonSerializer.Deserialize<FetchFailure>(OsFile.readAllText failurePath))
         with ex ->
-            logger.LogWarning(ex, "Failed to read failure record at {Path}", path)
+            logger.LogWarning(ex, "Failed to read failure record at {Path}", failurePath)
             None
     else
         None
 
+let private recordFailure (logger: ILogger) cachePath (kind: FetchFailureKind) =
+    let failurePath = failureFilePath cachePath
+    createDirectoryForPath failurePath
+
+    let failure =
+        match readFailureRecord logger cachePath with
+        | Some existing when existing.Kind = kind ->
+            { existing with
+                LastFailure = DateTimeOffset.Now
+                ConsecutiveFailures = existing.ConsecutiveFailures + 1 }
+        | _ ->
+            { LastFailure = DateTimeOffset.Now
+              ConsecutiveFailures = 1
+              Kind = kind }
+
+    OsFile.writeAllText failurePath (JsonSerializer.Serialize failure)
+
+let recordHttpFailure (logger: ILogger) cachePath =
+    recordFailure logger cachePath FetchFailureKind.HttpError
+
+let recordTimeoutFailure (logger: ILogger) cachePath =
+    recordFailure logger cachePath FetchFailureKind.Timeout
+
 let nextRetry (logger: ILogger) cachePath =
-    readFailure logger cachePath
+    readFailureRecord logger cachePath
     |> Option.map (fun failure ->
-        if failure.IsTimeout then
-            failure.LastFailure.AddMinutes(getTimeoutBackoffMinutes failure.ConsecutiveFailures)
-        else
-            failure.LastFailure.AddHours(getBackoffHours failure.ConsecutiveFailures))
+        match failure.Kind with
+        | Timeout -> failure.LastFailure.AddMinutes(getTimeoutBackoffMinutes failure.ConsecutiveFailures)
+        | HttpError -> failure.LastFailure.AddHours(getBackoffHours failure.ConsecutiveFailures))
 
 let clearExpiredCache (logger: ILogger) (cacheDir: OsPath) (retention: TimeSpan) =
     if not (OsDirectory.exists cacheDir) then


### PR DESCRIPTION
`recordFailure` and `readFailure` had duplicated "exists → read → deserialize → log on error" logic, and the failure kind was a bare `IsTimeout: bool` that needed `recordHttpFailure`/`recordTimeoutFailure` wrappers just to name the argument.

- `FetchFailure.IsTimeout: bool` → `Kind: FetchFailureKind`, a `[<Struct>]` DU (`HttpError | Timeout`) with a ~12-line `JsonConverter` so it persists as `"Kind":"Timeout"`. System.Text.Json refuses to serialize F# DUs otherwise; `[<Struct>]` keeps the default value sane (`HttpError`) so legacy files don't NRE.
- Legacy `.failures` files (pre-`Kind`, with or without the old `IsTimeout` flag) fall back to `HttpError` / long backoff and self-heal on the next failure. Covered by a theory test.
- Extract the shared read into `readFailureRecord` (renamed from `readFailure`); `recordFailure` reuses it, which also removes the `freshFailure` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)