### PR TITLE
Split request handling out of Program.fs into RequestHandlers.fs

### DIFF
--- a/SimpleRssServer.Tests/ProgramTests.fs
+++ b/SimpleRssServer.Tests/ProgramTests.fs
@@ -9,11 +9,13 @@ open System.Text.Json
 open System.Threading.Tasks
 open Xunit
 
+open SimpleRssServer.AppContext
 open SimpleRssServer.Cache
 open SimpleRssServer.Config
 open SimpleRssServer.DomainPrimitiveTypes
 open SimpleRssServer.DomainModel
 open SimpleRssServer.MemoryCache
+open SimpleRssServer.RequestHandlers
 open Program
 open TestHelpers
 

--- a/SimpleRssServer.Tests/RequestHandlingTests.fs
+++ b/SimpleRssServer.Tests/RequestHandlingTests.fs
@@ -10,10 +10,11 @@ open System.Threading.Tasks
 open Microsoft.Extensions.Logging.Abstractions
 open Xunit
 
+open SimpleRssServer.AppContext
 open SimpleRssServer.Config
 open SimpleRssServer.DomainPrimitiveTypes
 open SimpleRssServer.MemoryCache
-open Program
+open SimpleRssServer.RequestHandlers
 open TestHelpers
 
 let private freePort () =

--- a/SimpleRssServer/AppContext.fs
+++ b/SimpleRssServer/AppContext.fs
@@ -1,0 +1,16 @@
+module SimpleRssServer.AppContext
+
+open System.Net.Http
+open Microsoft.Extensions.Logging
+
+open SimpleRssServer.Config
+open SimpleRssServer.DomainPrimitiveTypes
+open SimpleRssServer.MemoryCache
+
+type AppContext =
+    { Client: HttpClient
+      Logger: ILogger
+      CacheConfig: CacheConfig
+      MemCache: InMemoryCache
+      CollectionsDir: OsPath
+      RequestLogPath: OsPath }

--- a/SimpleRssServer/Program.fs
+++ b/SimpleRssServer/Program.fs
@@ -1,242 +1,20 @@
-﻿open Microsoft.Extensions.Logging
+open Microsoft.Extensions.Logging
 open System
-open System.IO
 open System.Net
-open System.Text
 
+open SimpleRssServer.AppContext
 open SimpleRssServer.Cache
 open SimpleRssServer.Collections
 open SimpleRssServer.Config
 open SimpleRssServer.Helper
-open SimpleRssServer.HtmlRenderer
 open SimpleRssServer.Logging
 open SimpleRssServer.MemoryCache
 open SimpleRssServer.Request
+open SimpleRssServer.RequestHandlers
 open SimpleRssServer.RequestLog
-open SimpleRssServer.Router
 open SimpleRssServer.RssParser
 open SimpleRssServer.DomainModel
 open SimpleRssServer.DomainPrimitiveTypes
-
-type AppContext =
-    { Client: Http.HttpClient
-      Logger: ILogger
-      CacheConfig: CacheConfig
-      MemCache: InMemoryCache
-      CollectionsDir: OsPath
-      RequestLogPath: OsPath }
-
-let private readFormBody (httpCtx: HttpListenerContext) =
-    async {
-        use reader = new StreamReader(httpCtx.Request.InputStream, Encoding.UTF8)
-        let! body = reader.ReadToEndAsync() |> Async.AwaitTask
-        return Query.Create("?" + body)
-    }
-
-let processRssRequest (appCtx: AppContext) (query: string) =
-    let readCache = readFromCache appCtx.CacheConfig appCtx.MemCache
-    let applyBackoff = applyBackoff appCtx.Logger appCtx.CacheConfig
-
-    let fetchRssFeeds =
-        fetchAllRssFeeds appCtx.Client appCtx.Logger appCtx.CacheConfig UserFetchConfig
-
-    getRssUrls query
-    |> List.map (toUriProcessState >> readCache >> applyBackoff) // read cache, then skip feeds still in backoff
-    |> fetchRssFeeds
-    |> Async.RunSynchronously
-    |> List.map (readCache >> parseFeedResult appCtx.Logger) // read from cache in case of 304 Not modified
-    |> List.collect checkIfDiscoveryFeeds
-    |> List.map (readCache >> applyBackoff) // read discovered feeds from cache, then apply backoff
-    |> fetchRssFeeds
-    |> Async.RunSynchronously
-    |> List.map (
-        readCache // previous fetch can contain 304s
-        >> parseFeedResult appCtx.Logger
-        >> cacheSuccessfulFetch appCtx.CacheConfig
-    )
-    |> logSuccessfulFeedRequestsAndParses appCtx.RequestLogPath
-    |> List.map (feedToArticles >> updateMemoryCache appCtx.MemCache)
-    |> List.collect onlyFeedArticles
-
-let buildProcessedQuery (articles: Article list) : Query =
-    articles
-    |> List.map (fun a -> FeedUri.removeHttpsScheme a.FeedUrl)
-    |> List.distinct
-    |> fun u -> Query.CreateWithKey("rss", u)
-
-let private robotsTxt = File.ReadAllText(Path.Combine("site", "robots.txt"))
-let private sitemapXml = File.ReadAllText(Path.Combine("site", "sitemap.xml"))
-
-let private getSortedRssUris (q: Query) = q.GetValues "rss" |> List.sort
-
-let private writeResponse (httpCtx: HttpListenerContext) (content: string) =
-    async {
-        let buffer = content |> Encoding.UTF8.GetBytes
-        httpCtx.Response.ContentLength64 <- int64 buffer.Length
-        httpCtx.Response.ContentType <- "text/html"
-
-        do!
-            httpCtx.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length)
-            |> Async.AwaitTask
-
-        httpCtx.Response.OutputStream.Close()
-    }
-
-let private writeChunk (httpCtx: HttpListenerContext) (html: Html) =
-    async {
-        let bytes = html |> string |> Encoding.UTF8.GetBytes
-
-        do!
-            httpCtx.Response.OutputStream.WriteAsync(bytes, 0, bytes.Length)
-            |> Async.AwaitTask
-
-        do! httpCtx.Response.OutputStream.FlushAsync() |> Async.AwaitTask
-    }
-
-let private redirectTo (httpCtx: HttpListenerContext) (url: string) =
-    async {
-        httpCtx.Response.Redirect url
-        httpCtx.Response.OutputStream.Close()
-    }
-
-/// Streams a feeds page for the current request's own `?rss=` query, redirecting first
-/// if fetching/discovery normalized the feed list (e.g. stripped a scheme, followed a discovery link).
-let private streamFeedResponse
-    (appCtx: AppContext)
-    (httpCtx: HttpListenerContext)
-    (shell: Html)
-    (render: Query -> Article list -> Html)
-    =
-    async {
-        httpCtx.Response.SendChunked <- true
-        httpCtx.Response.ContentType <- "text/html"
-        do! writeChunk httpCtx shell
-
-        let articles = processRssRequest appCtx httpCtx.Request.Url.Query
-
-        let originalQuery = Query.Create httpCtx.Request.Url.Query
-        let processedQuery = buildProcessedQuery articles
-
-        let content =
-            if getSortedRssUris originalQuery <> getSortedRssUris processedQuery then
-                metaRefreshContent (string processedQuery)
-            else
-                render processedQuery articles
-
-        do! writeChunk httpCtx content
-        httpCtx.Response.OutputStream.Close()
-    }
-
-/// Looks up a collection by its id, rendering a "not found" page for an invalid
-/// or missing id, otherwise handing the saved feed list to `onFound`.
-let private loadCollectionOrNotFound
-    (appCtx: AppContext)
-    (httpCtx: HttpListenerContext)
-    (collectionId: CollectionId)
-    (onFound: string list -> Async<unit>)
-    =
-    async {
-        if not (isValidCollectionId collectionId) then
-            do! writeResponse httpCtx (collectionNotFoundPage collectionId |> string)
-        else
-            match tryLoad appCtx.CollectionsDir collectionId with
-            | None -> do! writeResponse httpCtx (collectionNotFoundPage collectionId |> string)
-            | Some feeds -> do! onFound feeds
-    }
-
-let private handleConfigPage (appCtx: AppContext) (httpCtx: HttpListenerContext) =
-    async {
-        let query = Query.Create httpCtx.Request.Url.Query
-
-        match query.GetValues "s" |> List.tryHead with
-        | Some rawId ->
-            let collectionId = CollectionId rawId
-
-            do!
-                loadCollectionOrNotFound appCtx httpCtx collectionId (fun feeds ->
-                    let rssUrls = feeds |> List.map FeedUri.createWithHttps
-                    writeResponse httpCtx (configPage rssUrls (Some collectionId) |> string))
-        | None -> do! writeResponse httpCtx (configPage (getRssUrls httpCtx.Request.Url.Query) None |> string)
-    }
-
-let private handleCreateCollection (appCtx: AppContext) (httpCtx: HttpListenerContext) =
-    async {
-        let! formData = readFormBody httpCtx
-        let feeds = formData.GetValues "rss"
-        let collectionId = generateCollectionId ()
-        save appCtx.CollectionsDir collectionId feeds
-        do! redirectTo httpCtx $"/s/{collectionId}"
-    }
-
-let private handleUpdateCollection (appCtx: AppContext) (httpCtx: HttpListenerContext) (collectionId: CollectionId) =
-    async {
-        if isValidCollectionId collectionId then
-            let! formData = readFormBody httpCtx
-            let feeds = formData.GetValues "rss"
-            save appCtx.CollectionsDir collectionId feeds
-            do! redirectTo httpCtx $"/s/{collectionId}"
-        else
-            do! writeResponse httpCtx (collectionNotFoundPage collectionId |> string)
-    }
-
-let private handleViewCollection
-    (appCtx: AppContext)
-    (httpCtx: HttpListenerContext)
-    (collectionId: CollectionId)
-    (shell: Html)
-    (content: Query -> Article list -> Html)
-    =
-    loadCollectionOrNotFound appCtx httpCtx collectionId (fun feeds ->
-        async {
-            touch appCtx.CollectionsDir collectionId
-            let collQuery = Query.CreateWithKey("rss", feeds)
-            httpCtx.Response.SendChunked <- true
-            httpCtx.Response.ContentType <- "text/html"
-
-            do! writeChunk httpCtx shell
-
-            let articles = processRssRequest appCtx (string collQuery)
-
-            do! writeChunk httpCtx (content collQuery articles)
-            httpCtx.Response.OutputStream.Close()
-        })
-
-let handleRequest (appCtx: AppContext) (httpCtx: HttpListenerContext) =
-    async {
-        appCtx.Logger.LogDebug $"Received request {httpCtx.Request.Url}"
-
-        match parseRoute httpCtx.Request.HttpMethod httpCtx.Request.RawUrl with
-        | ConfigPage -> do! handleConfigPage appCtx httpCtx
-        | ShuffleFeeds ->
-            let query = Query.Create httpCtx.Request.Url.Query
-
-            do! streamFeedResponse appCtx httpCtx (shuffledFeedsPageShell query) shuffledFeedsPageContent
-        | ChronologicalFeeds ->
-            let query = Query.Create httpCtx.Request.Url.Query
-
-            do! streamFeedResponse appCtx httpCtx (chronologicalFeedsPageShell query) chronologicalFeedsPageContent
-        | RobotsTxt -> do! writeResponse httpCtx robotsTxt
-        | SitemapXml -> do! writeResponse httpCtx sitemapXml
-        | CreateCollection -> do! handleCreateCollection appCtx httpCtx
-        | ViewCollectionShuffle collectionId ->
-            do!
-                handleViewCollection
-                    appCtx
-                    httpCtx
-                    collectionId
-                    (collectionShuffledPageShell collectionId)
-                    shuffledFeedsPageContent
-        | ViewCollection collectionId ->
-            do!
-                handleViewCollection
-                    appCtx
-                    httpCtx
-                    collectionId
-                    (collectionFeedsPageShell collectionId)
-                    chronologicalFeedsPageContent
-        | UpdateCollection collectionId -> do! handleUpdateCollection appCtx httpCtx collectionId
-        | LandingPage -> do! writeResponse httpCtx (landingPage |> string)
-    }
 
 let private getCacheAge (logger: ILogger) cacheConfig url =
     let cacheAge =
@@ -289,14 +67,6 @@ let rec clearCachePeriodically (appCtx: AppContext) (retention: TimeSpan) (perio
 
         do! Async.Sleep period
         return! clearCachePeriodically appCtx retention period
-    }
-
-let private handleRequestSafely (appCtx: AppContext) httpCtx =
-    async {
-        try
-            do! handleRequest appCtx httpCtx
-        with ex ->
-            appCtx.Logger.LogInformation("Request handling error: {Message}", ex.Message)
     }
 
 [<TailCall>]

--- a/SimpleRssServer/RequestHandlers.fs
+++ b/SimpleRssServer/RequestHandlers.fs
@@ -1,0 +1,240 @@
+module SimpleRssServer.RequestHandlers
+
+open Microsoft.Extensions.Logging
+open System.IO
+open System.Net
+open System.Text
+
+open SimpleRssServer.AppContext
+open SimpleRssServer.Cache
+open SimpleRssServer.Collections
+open SimpleRssServer.Config
+open SimpleRssServer.Helper
+open SimpleRssServer.HtmlRenderer
+open SimpleRssServer.MemoryCache
+open SimpleRssServer.Request
+open SimpleRssServer.RequestLog
+open SimpleRssServer.Router
+open SimpleRssServer.RssParser
+open SimpleRssServer.DomainModel
+open SimpleRssServer.DomainPrimitiveTypes
+
+let private readFormBody (httpCtx: HttpListenerContext) =
+    async {
+        use reader = new StreamReader(httpCtx.Request.InputStream, Encoding.UTF8)
+        let! body = reader.ReadToEndAsync() |> Async.AwaitTask
+        return Query.Create("?" + body)
+    }
+
+let processRssRequest (appCtx: AppContext) (query: string) =
+    let readCache = readFromCache appCtx.CacheConfig appCtx.MemCache
+    let applyBackoff = applyBackoff appCtx.Logger appCtx.CacheConfig
+
+    let fetchRssFeeds =
+        fetchAllRssFeeds appCtx.Client appCtx.Logger appCtx.CacheConfig UserFetchConfig
+
+    getRssUrls query
+    |> List.map (toUriProcessState >> readCache >> applyBackoff) // read cache, then skip feeds still in backoff
+    |> fetchRssFeeds
+    |> Async.RunSynchronously
+    |> List.map (readCache >> parseFeedResult appCtx.Logger) // read from cache in case of 304 Not modified
+    |> List.collect checkIfDiscoveryFeeds
+    |> List.map (readCache >> applyBackoff) // read discovered feeds from cache, then apply backoff
+    |> fetchRssFeeds
+    |> Async.RunSynchronously
+    |> List.map (
+        readCache // previous fetch can contain 304s
+        >> parseFeedResult appCtx.Logger
+        >> cacheSuccessfulFetch appCtx.CacheConfig
+    )
+    |> logSuccessfulFeedRequestsAndParses appCtx.RequestLogPath
+    |> List.map (feedToArticles >> updateMemoryCache appCtx.MemCache)
+    |> List.collect onlyFeedArticles
+
+let buildProcessedQuery (articles: Article list) : Query =
+    articles
+    |> List.map (fun a -> FeedUri.removeHttpsScheme a.FeedUrl)
+    |> List.distinct
+    |> fun u -> Query.CreateWithKey("rss", u)
+
+let private robotsTxt = File.ReadAllText(Path.Combine("site", "robots.txt"))
+let private sitemapXml = File.ReadAllText(Path.Combine("site", "sitemap.xml"))
+
+let private getSortedRssUris (q: Query) = q.GetValues "rss" |> List.sort
+
+let private writeResponse (httpCtx: HttpListenerContext) (content: string) =
+    async {
+        let buffer = content |> Encoding.UTF8.GetBytes
+        httpCtx.Response.ContentLength64 <- int64 buffer.Length
+        httpCtx.Response.ContentType <- "text/html"
+
+        do!
+            httpCtx.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length)
+            |> Async.AwaitTask
+
+        httpCtx.Response.OutputStream.Close()
+    }
+
+let private writeChunk (httpCtx: HttpListenerContext) (html: Html) =
+    async {
+        let bytes = html |> string |> Encoding.UTF8.GetBytes
+
+        do!
+            httpCtx.Response.OutputStream.WriteAsync(bytes, 0, bytes.Length)
+            |> Async.AwaitTask
+
+        do! httpCtx.Response.OutputStream.FlushAsync() |> Async.AwaitTask
+    }
+
+let private redirectTo (httpCtx: HttpListenerContext) (url: string) =
+    async {
+        httpCtx.Response.Redirect url
+        httpCtx.Response.OutputStream.Close()
+    }
+
+/// Streams a feeds page for the current request's own `?rss=` query, redirecting first
+/// if fetching/discovery normalized the feed list (e.g. stripped a scheme, followed a discovery link).
+let private streamFeedResponse
+    (appCtx: AppContext)
+    (httpCtx: HttpListenerContext)
+    (shell: Html)
+    (render: Query -> Article list -> Html)
+    =
+    async {
+        httpCtx.Response.SendChunked <- true
+        httpCtx.Response.ContentType <- "text/html"
+        do! writeChunk httpCtx shell
+
+        let articles = processRssRequest appCtx httpCtx.Request.Url.Query
+
+        let originalQuery = Query.Create httpCtx.Request.Url.Query
+        let processedQuery = buildProcessedQuery articles
+
+        let content =
+            if getSortedRssUris originalQuery <> getSortedRssUris processedQuery then
+                metaRefreshContent (string processedQuery)
+            else
+                render processedQuery articles
+
+        do! writeChunk httpCtx content
+        httpCtx.Response.OutputStream.Close()
+    }
+
+/// Looks up a collection by its id, rendering a "not found" page for an invalid
+/// or missing id, otherwise handing the saved feed list to `onFound`.
+let private loadCollectionOrNotFound
+    (appCtx: AppContext)
+    (httpCtx: HttpListenerContext)
+    (collectionId: CollectionId)
+    (onFound: string list -> Async<unit>)
+    =
+    async {
+        if not (isValidCollectionId collectionId) then
+            do! writeResponse httpCtx (collectionNotFoundPage collectionId |> string)
+        else
+            match tryLoad appCtx.CollectionsDir collectionId with
+            | None -> do! writeResponse httpCtx (collectionNotFoundPage collectionId |> string)
+            | Some feeds -> do! onFound feeds
+    }
+
+let private handleConfigPage (appCtx: AppContext) (httpCtx: HttpListenerContext) =
+    async {
+        let query = Query.Create httpCtx.Request.Url.Query
+
+        match query.GetValues "s" |> List.tryHead with
+        | Some rawId ->
+            let collectionId = CollectionId rawId
+
+            do!
+                loadCollectionOrNotFound appCtx httpCtx collectionId (fun feeds ->
+                    let rssUrls = feeds |> List.map FeedUri.createWithHttps
+                    writeResponse httpCtx (configPage rssUrls (Some collectionId) |> string))
+        | None -> do! writeResponse httpCtx (configPage (getRssUrls httpCtx.Request.Url.Query) None |> string)
+    }
+
+let private handleCreateCollection (appCtx: AppContext) (httpCtx: HttpListenerContext) =
+    async {
+        let! formData = readFormBody httpCtx
+        let feeds = formData.GetValues "rss"
+        let collectionId = generateCollectionId ()
+        save appCtx.CollectionsDir collectionId feeds
+        do! redirectTo httpCtx $"/s/{collectionId}"
+    }
+
+let private handleUpdateCollection (appCtx: AppContext) (httpCtx: HttpListenerContext) (collectionId: CollectionId) =
+    async {
+        if isValidCollectionId collectionId then
+            let! formData = readFormBody httpCtx
+            let feeds = formData.GetValues "rss"
+            save appCtx.CollectionsDir collectionId feeds
+            do! redirectTo httpCtx $"/s/{collectionId}"
+        else
+            do! writeResponse httpCtx (collectionNotFoundPage collectionId |> string)
+    }
+
+let private handleViewCollection
+    (appCtx: AppContext)
+    (httpCtx: HttpListenerContext)
+    (collectionId: CollectionId)
+    (shell: Html)
+    (content: Query -> Article list -> Html)
+    =
+    loadCollectionOrNotFound appCtx httpCtx collectionId (fun feeds ->
+        async {
+            touch appCtx.CollectionsDir collectionId
+            let collQuery = Query.CreateWithKey("rss", feeds)
+            httpCtx.Response.SendChunked <- true
+            httpCtx.Response.ContentType <- "text/html"
+
+            do! writeChunk httpCtx shell
+
+            let articles = processRssRequest appCtx (string collQuery)
+
+            do! writeChunk httpCtx (content collQuery articles)
+            httpCtx.Response.OutputStream.Close()
+        })
+
+let handleRequest (appCtx: AppContext) (httpCtx: HttpListenerContext) =
+    async {
+        appCtx.Logger.LogDebug $"Received request {httpCtx.Request.Url}"
+
+        match parseRoute httpCtx.Request.HttpMethod httpCtx.Request.RawUrl with
+        | ConfigPage -> do! handleConfigPage appCtx httpCtx
+        | ShuffleFeeds ->
+            let query = Query.Create httpCtx.Request.Url.Query
+
+            do! streamFeedResponse appCtx httpCtx (shuffledFeedsPageShell query) shuffledFeedsPageContent
+        | ChronologicalFeeds ->
+            let query = Query.Create httpCtx.Request.Url.Query
+
+            do! streamFeedResponse appCtx httpCtx (chronologicalFeedsPageShell query) chronologicalFeedsPageContent
+        | RobotsTxt -> do! writeResponse httpCtx robotsTxt
+        | SitemapXml -> do! writeResponse httpCtx sitemapXml
+        | CreateCollection -> do! handleCreateCollection appCtx httpCtx
+        | ViewCollectionShuffle collectionId ->
+            do!
+                handleViewCollection
+                    appCtx
+                    httpCtx
+                    collectionId
+                    (collectionShuffledPageShell collectionId)
+                    shuffledFeedsPageContent
+        | ViewCollection collectionId ->
+            do!
+                handleViewCollection
+                    appCtx
+                    httpCtx
+                    collectionId
+                    (collectionFeedsPageShell collectionId)
+                    chronologicalFeedsPageContent
+        | UpdateCollection collectionId -> do! handleUpdateCollection appCtx httpCtx collectionId
+        | LandingPage -> do! writeResponse httpCtx (landingPage |> string)
+    }
+
+let handleRequestSafely (appCtx: AppContext) httpCtx =
+    async {
+        try
+            do! handleRequest appCtx httpCtx
+        with ex ->
+            appCtx.Logger.LogInformation("Request handling error: {Message}", ex.Message)
+    }

--- a/SimpleRssServer/SimpleRssServer.fsproj
+++ b/SimpleRssServer/SimpleRssServer.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="Logging.fs" />
     <Compile Include="HttpClient.fs" />
     <Compile Include="MemoryCache.fs" />
+    <Compile Include="AppContext.fs" />
     <Compile Include="Cache.fs" />
     <Compile Include="RequestLog.fs" />
     <Compile Include="Collections.fs" />
@@ -19,6 +20,7 @@
     <Compile Include="RssParser.fs" />
     <Compile Include="HtmlRenderer.fs" />
     <Compile Include="ArgParser.fs" />
+    <Compile Include="RequestHandlers.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
`Program.fs` was mixing four unrelated concerns in one 369-line file: the fetch pipeline, raw HTTP I/O helpers, all route handlers, and app bootstrap/background loops. Same shape `Router.fs` already separated out for route parsing (#112) — `Program.fs` should hold only the composition root and scheduling.

- New `AppContext.fs`: just the `AppContext` record, so both `Program.fs` and `RequestHandlers.fs` can depend on it without a cycle.
- New `RequestHandlers.fs`: `processRssRequest`/`buildProcessedQuery` fetch pipeline, `writeResponse`/`writeChunk`/`redirectTo` HTTP I/O helpers, all `handle*` route handlers, and `handleRequest`/`handleRequestSafely`.
- `Program.fs` now only has `updateCache`, the two background loops, `serverLoop`, `startServer` and `main`.
- Test files updated to open the new modules instead of `Program`.

No behavior change.

## Test plan
- [x] `dotnet build -c Release` — no warnings
- [x] `dotnet test` — 210/210 passing
- [x] `fantomas .` — unchanged
- [x] `dotnet fsharplint lint SimpleRssServer.sln` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)