### PR TITLE
Replace "No changes" string sentinel with FetchResponse DU

### DIFF
--- a/SimpleRssServer.Tests/HttpClientTests.fs
+++ b/SimpleRssServer.Tests/HttpClientTests.fs
@@ -35,7 +35,7 @@ let ``Test fetchUrlAsync with successful response`` () =
         fetchUrlAsync client logger (Uri "http://example.com") (Some DateTimeOffset.Now) (TimeSpan.FromSeconds 5.0)
         |> Async.RunSynchronously
 
-    Assert.Equal(expectedContent, getOk result)
+    Assert.Equal(Content expectedContent, getOk result)
 
 [<Fact>]
 let ``Test fetchUrlAsync with unsuccessful response`` () =
@@ -81,7 +81,7 @@ let ``GetAsync returns NotModified or OK based on IfModifiedSince header`` () =
         fetchUrlAsync client logger url (Some lastModifiedDate) (TimeSpan.FromSeconds 5.0)
         |> Async.RunSynchronously
 
-    Assert.Equal("No changes", getOk result1)
+    Assert.Equal(NotModified, getOk result1)
 
     // Case 2: When If-Modified-Since is before lastModifiedDate
     let earlierDate = lastModifiedDate.AddDays -1.0
@@ -90,14 +90,14 @@ let ``GetAsync returns NotModified or OK based on IfModifiedSince header`` () =
         fetchUrlAsync client logger url (Some earlierDate) (TimeSpan.FromSeconds 5.0)
         |> Async.RunSynchronously
 
-    Assert.Equal("Content has changed since the last modification date", getOk result2)
+    Assert.Equal(Content "Content has changed since the last modification date", getOk result2)
 
     // Case 3: When If-Modified-Since is not provided
     let result3 =
         fetchUrlAsync client logger url None (TimeSpan.FromSeconds 5.0)
         |> Async.RunSynchronously
 
-    Assert.Equal("Content has changed since the last modification date", getOk result3)
+    Assert.Equal(Content "Content has changed since the last modification date", getOk result3)
 
 type DelayedResponseHandler(delay: TimeSpan) =
     inherit HttpMessageHandler()

--- a/SimpleRssServer/DomainModel.fs
+++ b/SimpleRssServer/DomainModel.fs
@@ -24,6 +24,10 @@ and DomainError =
     | HttpRequestNonSuccessStatus of Uri * HttpStatusCode
     | HttpException of Uri * Exception
 
+type FetchResponse =
+    | Content of string
+    | NotModified
+
 type Article =
     { PostDate: DateTime option
       Title: string

--- a/SimpleRssServer/HttpClient.fs
+++ b/SimpleRssServer/HttpClient.fs
@@ -35,9 +35,9 @@ let fetchUrlAsync
 
             if response.IsSuccessStatusCode then
                 let! content = response.Content.ReadAsStringAsync() |> Async.AwaitTask
-                return Ok content
+                return Ok(Content content)
             else if response.StatusCode = HttpStatusCode.NotModified then
-                return Ok "No changes"
+                return Ok NotModified
             else
                 logger.LogError $"Failed to get {uri}. Error: {response.StatusCode}."
                 return Error(HttpRequestNonSuccessStatus(uri, response.StatusCode))

--- a/SimpleRssServer/Program.fs
+++ b/SimpleRssServer/Program.fs
@@ -6,7 +6,6 @@ open SimpleRssServer.AppContext
 open SimpleRssServer.Cache
 open SimpleRssServer.Collections
 open SimpleRssServer.Config
-open SimpleRssServer.Helper
 open SimpleRssServer.Logging
 open SimpleRssServer.MemoryCache
 open SimpleRssServer.Request

--- a/SimpleRssServer/Request.fs
+++ b/SimpleRssServer/Request.fs
@@ -19,11 +19,11 @@ let private fetchUri client logger (cacheConfig: CacheConfig) (fetchConfig: Fetc
 
         return
             match r with
-            | Ok "No changes" ->
+            | Ok NotModified ->
                 OsFile.setLastWriteTime cachePath DateTime.Now
                 clearFailure cachePath
                 TryFetchFromCache uri
-            | Ok content ->
+            | Ok(Content content) ->
                 clearFailure cachePath
                 UnparsedHttpResponse(content, uri)
             | Error e ->


### PR DESCRIPTION
## Summary
- `fetchUrlAsync` returned `Ok "No changes"` as a magic-string sentinel for HTTP 304 responses, matched via a string literal in `Request.fs`
- Replaces it with a `FetchResponse` DU (`Content of string | NotModified`) so the 304 case is compiler-checked instead of string-matched

## Test plan
- [x] `dotnet test` — all 210 tests pass