### PR TITLE
Dedup cache-path/version derivation, drop dead code

### DIFF
--- a/SimpleRssServer/Cache.fs
+++ b/SimpleRssServer/Cache.fs
@@ -2,7 +2,6 @@ module SimpleRssServer.Cache
 
 open Microsoft.Extensions.Logging
 open System
-open System.IO
 open System.Text
 open System.Text.Json
 open System.Text.Json.Serialization
@@ -51,11 +50,14 @@ let getTimeoutBackoffMinutes failures =
 let isCacheExpired (cacheConfig: CacheConfig) (modTime: DateTimeOffset) =
     (DateTimeOffset.Now - modTime) > cacheConfig.Expiration
 
+// File.GetLastWriteTime returns this sentinel for a missing file, letting us check
+// existence and last-write-time in a single filesystem stat instead of two.
+let private missingFileTimestamp = DateTime.FromFileTime 0L
+
 let fileLastModified (path: OsPath) =
-    if OsFile.exists path then
-        OsFile.getLastWriteTime path |> DateTimeOffset |> Some
-    else
-        None
+    match OsFile.getLastWriteTime path with
+    | t when t = missingFileTimestamp -> None
+    | t -> Some(DateTimeOffset t)
 
 let readCache (cachePath: OsPath) =
     if OsFile.exists cachePath then
@@ -67,7 +69,7 @@ let createDirectoryForPath (path: OsPath) =
     let (OsPath dir) = OsPath.getDirectoryName path
 
     if not (String.IsNullOrEmpty dir) then
-        Directory.CreateDirectory dir |> ignore
+        OsDirectory.create (OsPath dir)
 
 let writeCache cachePath (content: string) =
     createDirectoryForPath cachePath
@@ -124,15 +126,16 @@ let clearExpiredCache (logger: ILogger) (cacheDir: OsPath) (retention: TimeSpan)
     if not (OsDirectory.exists cacheDir) then
         logger.LogWarning("Cache directory {Dir} does not exist", cacheDir)
     else
-        OsDirectory.getFiles cacheDir
-        |> Array.filter (OsFile.isOlderThan retention)
-        |> Array.iter OsFile.delete
+        cacheDir |> OsDirectory.deleteFilesOlderThan retention (fun _ -> true)
 
 let private invalidFilenameCharsRegex =
     RegularExpressions.Regex("[.?=:/]+", RegularExpressions.RegexOptions.Compiled)
 
 let convertUrlToValidFilename (uri: Uri) =
     invalidFilenameCharsRegex.Replace(uri.AbsoluteUri, "_") |> Filename
+
+let cachePathFor (cacheConfig: CacheConfig) (uri: Uri) =
+    OsPath.combine cacheConfig.Dir (convertUrlToValidFilename uri)
 
 type BackoffState =
     | ReadyToFetch
@@ -156,7 +159,7 @@ let computeBackoffState (cacheModified: DateTimeOffset option) (nextAttempt: Dat
 let applyBackoff (logger: ILogger) (cacheConfig: CacheConfig) (ups: UriProcessState) : UriProcessState =
     match ups with
     | PendingFetch(cacheModified, uri) ->
-        let cachePath = OsPath.combine cacheConfig.Dir (convertUrlToValidFilename uri)
+        let cachePath = cachePathFor cacheConfig uri
 
         match computeBackoffState cacheModified (nextRetry logger cachePath) with
         | ReadyToFetch -> ups
@@ -170,7 +173,7 @@ let readFromCache (cacheConfig: CacheConfig) (memCache: InMemoryCache) (ups: Uri
         match memCache.TryGet(u.AbsoluteUri, cacheConfig.Expiration) with
         | Some articles -> FeedArticles articles
         | None ->
-            let cachePath = OsPath.combine cacheConfig.Dir (convertUrlToValidFilename u)
+            let cachePath = cachePathFor cacheConfig u
             let cacheModified = fileLastModified cachePath
 
             match cacheModified with
@@ -183,7 +186,7 @@ let readFromCache (cacheConfig: CacheConfig) (memCache: InMemoryCache) (ups: Uri
     | ProcessingError e ->
         let (MessageUri uriStr) = e
         let feedUri = Uri uriStr
-        let cachePath = OsPath.combine cacheConfig.Dir (convertUrlToValidFilename feedUri)
+        let cachePath = cachePathFor cacheConfig feedUri
 
         match readCache cachePath with
         | Some content -> UnparsedStaleCachedContent(content, feedUri, e)
@@ -193,9 +196,7 @@ let readFromCache (cacheConfig: CacheConfig) (memCache: InMemoryCache) (ups: Uri
 let cacheSuccessfulFetch cacheConfig ups =
     match ups with
     | ParsedLiveFeed(xml, feed) ->
-        let cachePath =
-            OsPath.combine cacheConfig.Dir (convertUrlToValidFilename (Uri feed.Link))
-
+        let cachePath = cachePathFor cacheConfig (Uri feed.Link)
         writeCache cachePath xml.Value
     | _ -> ()
 

--- a/SimpleRssServer/Collections.fs
+++ b/SimpleRssServer/Collections.fs
@@ -5,6 +5,7 @@ open System.Security.Cryptography
 open System.Text.RegularExpressions
 
 open SimpleRssServer.DomainPrimitiveTypes
+open SimpleRssServer.Helper
 
 let private toBase64Url (bytes: byte[]) =
     Convert.ToBase64String(bytes).Replace('+', '-').Replace('/', '_').TrimEnd('=')
@@ -24,10 +25,7 @@ let tryLoad (dir: OsPath) (collectionId: CollectionId) : string list option =
     let path = collectionFilePath dir collectionId
 
     if OsFile.exists path then
-        OsFile.readAllLines path
-        |> Array.toList
-        |> List.filter (fun s -> s.Trim() <> "")
-        |> Some
+        OsFile.readAllLines path |> Array.toList |> List.filter isText |> Some
     else
         None
 
@@ -36,7 +34,5 @@ let touch (dir: OsPath) (collectionId: CollectionId) =
 
 let deleteInactive (dir: OsPath) (retention: TimeSpan) =
     if OsDirectory.exists dir then
-        OsDirectory.getFiles dir
-        |> Array.filter (fun (OsPath p) -> p.EndsWith ".txt")
-        |> Array.filter (OsFile.isOlderThan retention)
-        |> Array.iter OsFile.delete
+        dir
+        |> OsDirectory.deleteFilesOlderThan retention (fun (OsPath p) -> p.EndsWith ".txt")

--- a/SimpleRssServer/Config.fs
+++ b/SimpleRssServer/Config.fs
@@ -28,7 +28,8 @@ let CacheRetention = TimeSpan.FromDays 7.0
 
 let ArticleDescriptionLength = 255
 
-let version = Assembly.GetExecutingAssembly().GetName().Version.ToString()
+let assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version
+let version = assemblyVersion.ToString()
 
 let CollectionsDir = OsPath "collections"
 let CollectionRetention = TimeSpan.FromDays 90.0

--- a/SimpleRssServer/DomainModel.fs
+++ b/SimpleRssServer/DomainModel.fs
@@ -6,9 +6,7 @@ open SimpleRssServer.DomainPrimitiveTypes
 open System.Net
 open Roald87.FeedReader
 
-type FeedUri = FeedUri of Uri
-
-and DomainError =
+type DomainError =
     // Uri errors
     | InvalidUriHostname of InvalidUri
     | InvalidUriFormat of InvalidUri * Exception

--- a/SimpleRssServer/DomainPrimitiveTypes.fs
+++ b/SimpleRssServer/DomainPrimitiveTypes.fs
@@ -75,18 +75,6 @@ module OsPath =
     let join (OsPath path) (filename: string) = Path.Combine(path, filename) |> OsPath
     let getDirectoryName (OsPath path) = Path.GetDirectoryName path |> OsPath
 
-module OsDirectory =
-    let create (OsPath path) =
-        Directory.CreateDirectory path |> ignore
-
-    let deleteRecursive (OsPath path) =
-        Directory.Delete(path, recursive = true)
-
-    let exists (OsPath path) = Directory.Exists path
-
-    let getFiles (OsPath path) =
-        Directory.GetFiles path |> Array.map OsPath
-
 module OsFile =
     let exists (OsPath path) = File.Exists path
     let delete (OsPath path) = File.Delete path
@@ -102,6 +90,25 @@ module OsFile =
 
     let writeAllLines (OsPath path) (lines: string list) = File.WriteAllLines(path, lines)
     let writeAllText (OsPath path) (content: string) = File.WriteAllText(path, content)
+
+module OsDirectory =
+    let create (OsPath path) =
+        Directory.CreateDirectory path |> ignore
+
+    let deleteRecursive (OsPath path) =
+        Directory.Delete(path, recursive = true)
+
+    let exists (OsPath path) = Directory.Exists path
+
+    let getFiles (OsPath path) =
+        Directory.GetFiles path |> Array.map OsPath
+
+    /// Deletes files in `dir` matching `predicate` that haven't been written to in `retention`.
+    let deleteFilesOlderThan (retention: TimeSpan) (predicate: OsPath -> bool) (dir: OsPath) =
+        getFiles dir
+        |> Array.filter predicate
+        |> Array.filter (OsFile.isOlderThan retention)
+        |> Array.iter OsFile.delete
 
 type CollectionId =
     | CollectionId of string

--- a/SimpleRssServer/HtmlRenderer.fs
+++ b/SimpleRssServer/HtmlRenderer.fs
@@ -52,7 +52,7 @@ let convertArticleToHtml (deleteButton: Html) (article: Article) : Html =
     |> Html
 
 let versionNumber =
-    let version = Reflection.Assembly.GetExecutingAssembly().GetName().Version
+    let version = SimpleRssServer.Config.assemblyVersion
     $"{version.Major}.{version.Minor}.{version.Build}"
 
 let private aboveFeedInput: Html =
@@ -159,7 +159,7 @@ let configPage (rssUrls: Result<Uri, UriError> list) (existingCollectionId: Coll
     let validRssUris =
         rssUrls
         |> validUris
-        |> List.map (fun u -> u.AbsoluteUri.Replace("https://", ""))
+        |> List.map (fun u -> FeedUri.removeHttpsScheme u.AbsoluteUri)
         |> String.concat "\n"
 
     head
@@ -232,9 +232,6 @@ let metaRefreshContent (redirectUrl: string) : Html =
 
 let chronologicalFeedsPage (query: Query) (rssItems: Article list) : Html =
     chronologicalFeedsPageShell query + chronologicalFeedsPageContent query rssItems
-
-let shuffledFeedsPage (query: Query) (rssItems: Article list) : Html =
-    shuffledFeedsPageShell query + shuffledFeedsPageContent query rssItems
 
 let collectionFeedsPageShell (collectionId: CollectionId) : Html =
     let configHref = $"/config.html?s=%s{string collectionId}"


### PR DESCRIPTION
## Summary
- Consolidate repeated logic: assembly-version lookup, expired-file deletion loop (`Cache.clearExpiredCache`/`Collections.deleteInactive`), and cache-path derivation (`OsPath.combine cacheConfig.Dir (convertUrlToValidFilename uri)`, repeated 4x in Cache.fs + Request.fs + Program.fs)
- Remove dead code: unused `DomainModel.FeedUri` type (shadowed by the real `FeedUri` module) and uncalled `HtmlRenderer.shuffledFeedsPage` (the live `/shuffle` route uses `shuffledFeedsPageShell`/`shuffledFeedsPageContent` separately, both untouched)
- Reuse `Helper.isText` instead of a local re-implementation in `Collections.fs`
- Cut `Cache.fileLastModified` from two filesystem stats to one, using the sentinel timestamp `File.GetLastWriteTime` returns for a missing file

No behavior change. Found via a whole-codebase `/simplify` pass.

## Test plan
- [x] `dotnet build -c Release` — clean, 0 warnings
- [x] `dotnet test` — 210/210 passing