### PR TITLE
Add typed Uri accessor to DomainError

### DIFF
--- a/SimpleRssServer.Tests/CacheTests.fs
+++ b/SimpleRssServer.Tests/CacheTests.fs
@@ -9,6 +9,7 @@ open SimpleRssServer.Cache
 open SimpleRssServer.Config
 open SimpleRssServer.DomainModel
 open SimpleRssServer.DomainPrimitiveTypes
+open SimpleRssServer.MemoryCache
 open TestHelpers
 
 [<Fact>]
@@ -377,3 +378,35 @@ let ``applyBackoff: states other than PendingFetch pass through`` () =
     let ups = FeedArticles []
 
     Assert.Equal(ups, applyBackoff NullLogger.Instance (cacheConfigIn tmp.Path) ups)
+
+[<Fact>]
+let ``readFromCache: ProcessingError with no associated Uri (invalid hostname) passes through unchanged`` () =
+    use tmp = new TempDir()
+    let memCache = InMemoryCache NullLogger.Instance
+    let ups = ProcessingError(InvalidUriHostname(InvalidUri.Create "invalid-url"))
+
+    Assert.Equal(ups, readFromCache (cacheConfigIn tmp.Path) memCache ups)
+
+[<Fact>]
+let ``readFromCache: ProcessingError with a Uri and no stale cache passes through unchanged`` () =
+    use tmp = new TempDir()
+    let memCache = InMemoryCache NullLogger.Instance
+    let uri = Uri "https://example.com/feed"
+    let ups = ProcessingError(PreviousHttpRequestFailed(uri, TimeSpan.FromHours 1.0))
+
+    Assert.Equal(ups, readFromCache (cacheConfigIn tmp.Path) memCache ups)
+
+[<Fact>]
+let ``readFromCache: ProcessingError with a Uri and a stale cache returns UnparsedStaleCachedContent`` () =
+    use tmp = new TempDir()
+    let memCache = InMemoryCache NullLogger.Instance
+    let uri = Uri "https://example.com/feed"
+    let error = PreviousHttpRequestFailed(uri, TimeSpan.FromHours 1.0)
+    writeCache (cachePathFor (cacheConfigIn tmp.Path) uri) "<rss>stale</rss>"
+
+    match readFromCache (cacheConfigIn tmp.Path) memCache (ProcessingError error) with
+    | UnparsedStaleCachedContent(content, u, e) ->
+        Assert.Equal("<rss>stale</rss>", content)
+        Assert.Equal(uri, u)
+        Assert.Equal(error, e)
+    | other -> Assert.Fail $"expected UnparsedStaleCachedContent, got {other}"

--- a/SimpleRssServer/Cache.fs
+++ b/SimpleRssServer/Cache.fs
@@ -183,9 +183,7 @@ let readFromCache (cacheConfig: CacheConfig) (memCache: InMemoryCache) (ups: Uri
                 match readCache cachePath with
                 | Some s -> UnparsedCachedContent(s, u)
                 | None -> PendingFetch(None, u)
-    | ProcessingError e ->
-        let (MessageUri uriStr) = e
-        let feedUri = Uri uriStr
+    | ProcessingError(DomainErrorUri feedUri as e) ->
         let cachePath = cachePathFor cacheConfig feedUri
 
         match readCache cachePath with

--- a/SimpleRssServer/DomainModel.fs
+++ b/SimpleRssServer/DomainModel.fs
@@ -67,3 +67,17 @@ module ActivePatterns =
         | HttpException(uri, _) -> uri.AbsoluteUri
         | InvalidRssFeedFormat(uri, _) -> uri.AbsoluteUri
         | NoRssFeedsFoundInPage uri -> uri.AbsoluteUri
+
+    /// The feed's Uri, for errors that carry one. Invalid-uri errors carry only the
+    /// raw (possibly unparsable) string the user entered, so they have none.
+    let (|DomainErrorUri|_|) (msg: DomainError) =
+        match msg with
+        | InvalidUriHostname _
+        | InvalidUriFormat _ -> None
+        | PreviousHttpRequestFailed(uri, _) -> Some uri
+        | PreviousHttpRequestFailedButPageCached(uri, _) -> Some uri
+        | HttpRequestTimedOut(uri, _) -> Some uri
+        | HttpRequestNonSuccessStatus(uri, _) -> Some uri
+        | HttpException(uri, _) -> Some uri
+        | InvalidRssFeedFormat(uri, _) -> Some uri
+        | NoRssFeedsFoundInPage uri -> Some uri


### PR DESCRIPTION
## Summary
- `Cache.readFromCache`'s stale-cache-fallback branch reconstructed a `System.Uri` by re-parsing the `MessageUri` active pattern's string output. `MessageUri` is a display-string accessor meant for `RssParser`'s error-article rendering — reaching into it from the cache layer was a layer violation.
- Worse: for the two invalid-uri error variants (`InvalidUriHostname`/`InvalidUriFormat`), `MessageUri` returns the *raw, possibly-unparsable string the user typed*, not a real URI. Reparsing that as a `Uri` there would throw `UriFormatException` if one of those errors ever reached `readFromCache` — which it can, since URL parsing happens right at the top of `processRssRequest`, before any HTTP fetch. This path had no test coverage.
- Added a `DomainErrorUri` active pattern in `DomainModel.fs` that returns the real typed `Uri` for the error variants that carry one, and `None` for the two that don't. `Cache.fs` now matches on it directly instead of reparsing a string.
- Added 3 regression tests in `CacheTests.fs`, including one that would have crashed on the old code path.

This was finding #2 from the [/simplify cleanup pass](https://github.com/Roald87/rssrdr/pull/124).

## Test plan
- [x] `dotnet build -c Release` — clean, 0 warnings
- [x] `dotnet test` — 213/213 passing (3 new)