### PR TITLE
Replace collection-lookup CPS callback with plain Option match

### DIFF
--- a/SimpleRssServer.Tests/CollectionsTests.fs
+++ b/SimpleRssServer.Tests/CollectionsTests.fs
@@ -49,6 +49,14 @@ let ``tryLoad returns None for missing file`` () =
     Assert.Equal(None, tryLoad dir.Path (CollectionId "nonexistent"))
 
 [<Fact>]
+let ``tryLoad returns None for an invalid id even if a matching file exists`` () =
+    use dir = new TempDir()
+    let collectionId = CollectionId "short"
+    OsFile.writeAllLines (OsPath.join dir.Path "short.txt") [ "example.com/feed" ]
+
+    Assert.Equal(None, tryLoad dir.Path collectionId)
+
+[<Fact>]
 let ``touch updates last-write-time`` () =
     use dir = new TempDir()
     let collectionId = CollectionId "testcode2"

--- a/SimpleRssServer/Collections.fs
+++ b/SimpleRssServer/Collections.fs
@@ -24,7 +24,7 @@ let save (dir: OsPath) (collectionId: CollectionId) (feeds: string list) =
 let tryLoad (dir: OsPath) (collectionId: CollectionId) : string list option =
     let path = collectionFilePath dir collectionId
 
-    if OsFile.exists path then
+    if isValidCollectionId collectionId && OsFile.exists path then
         OsFile.readAllLines path |> Array.toList |> List.filter isText |> Some
     else
         None

--- a/SimpleRssServer/RequestHandlers.fs
+++ b/SimpleRssServer/RequestHandlers.fs
@@ -140,23 +140,6 @@ let private streamFeedResponse
                     render processedQuery articles
         })
 
-/// Looks up a collection by its id, rendering a "not found" page for an invalid
-/// or missing id, otherwise handing the saved feed list to `onFound`.
-let private loadCollectionOrNotFound
-    (appCtx: AppContext)
-    (httpCtx: HttpListenerContext)
-    (collectionId: CollectionId)
-    (onFound: string list -> Async<unit>)
-    =
-    async {
-        if not (isValidCollectionId collectionId) then
-            do! writeResponse httpCtx (collectionNotFoundPage collectionId |> string)
-        else
-            match tryLoad appCtx.CollectionsDir collectionId with
-            | None -> do! writeResponse httpCtx (collectionNotFoundPage collectionId |> string)
-            | Some feeds -> do! onFound feeds
-    }
-
 let private handleConfigPage (appCtx: AppContext) (httpCtx: HttpListenerContext) =
     async {
         let query = Query.Create httpCtx.Request.Url.Query
@@ -165,10 +148,11 @@ let private handleConfigPage (appCtx: AppContext) (httpCtx: HttpListenerContext)
         | Some rawId ->
             let collectionId = CollectionId rawId
 
-            do!
-                loadCollectionOrNotFound appCtx httpCtx collectionId (fun feeds ->
-                    let rssUrls = feeds |> List.map FeedUri.createWithHttps
-                    writeResponse httpCtx (configPage rssUrls (Some collectionId) |> string))
+            match tryLoad appCtx.CollectionsDir collectionId with
+            | None -> do! writeResponse httpCtx (collectionNotFoundPage collectionId |> string)
+            | Some feeds ->
+                let rssUrls = feeds |> List.map FeedUri.createWithHttps
+                do! writeResponse httpCtx (configPage rssUrls (Some collectionId) |> string)
         | None -> do! writeResponse httpCtx (configPage (getRssUrls httpCtx.Request.Url.Query) None |> string)
     }
 
@@ -199,15 +183,17 @@ let private handleViewCollection
     (shell: Html)
     (content: Query -> Article list -> Html)
     =
-    loadCollectionOrNotFound appCtx httpCtx collectionId (fun feeds ->
-        async {
+    async {
+        match tryLoad appCtx.CollectionsDir collectionId with
+        | None -> do! writeResponse httpCtx (collectionNotFoundPage collectionId |> string)
+        | Some feeds ->
             touch appCtx.CollectionsDir collectionId
             let collQuery = Query.CreateWithKey("rss", feeds)
 
             do!
                 streamChunkedPage httpCtx shell (fun () ->
                     async { return content collQuery (processRssRequest appCtx (string collQuery)) })
-        })
+    }
 
 let handleRequest (appCtx: AppContext) (httpCtx: HttpListenerContext) =
     async {


### PR DESCRIPTION
## Summary
- `loadCollectionOrNotFound` used an unusual `onFound` continuation-passing pattern not used elsewhere in the codebase
- Fold `isValidCollectionId` into `Collections.tryLoad` so it's safe by construction, then inline a plain `None`/`Some` match at each call site (`handleConfigPage`, `handleViewCollection`) instead

## Test plan
- [x] `dotnet build`
- [x] `dotnet test` (223 passed)